### PR TITLE
CB-97 [feat]: add https address

### DIFF
--- a/src/main/java/com/pinkdumbell/cocobob/config/WebConfig.java
+++ b/src/main/java/com/pinkdumbell/cocobob/config/WebConfig.java
@@ -11,7 +11,7 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/v1/**")
-            .allowedOrigins("http://localhost:3000","http://3.37.136.84/")
+            .allowedOrigins("http://localhost:3000","http://3.37.136.84/","http://petalog.us/","https://petalog.us/")
             .allowedMethods(
                 HttpMethod.GET.name(),
                 HttpMethod.HEAD.name(),


### PR DESCRIPTION
도메인 구매 및 https 적용

[CB-93]

🔨 Jira 태스크
[CB-97]  [BE] https 설정이 필요함


📐 구현한 내용
프론트 엔드
https://petalog.us/ 

백엔드
https://api.petalog.us/

도메인 구매 및 도메인 https 적용

🚧 논의 사항
프론트 엔드에서 사용할 수 있게 cors에 추가하였습니다.




[CB-93]: https://cocobob.atlassian.net/browse/CB-93?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CB-97]: https://cocobob.atlassian.net/browse/CB-97?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ