### PR TITLE
CB-185 [refactor]: modify wrong context error message

### DIFF
--- a/src/main/java/com/pinkdumbell/cocobob/exception/ErrorCode.java
+++ b/src/main/java/com/pinkdumbell/cocobob/exception/ErrorCode.java
@@ -7,7 +7,7 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 @Getter
 public enum ErrorCode {
-    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않은 계정입니다."),
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 계정입니다."),
     INVALID_PASSWORD(HttpStatus.FORBIDDEN, "비밀번호가 일치하지 않습니다."),
     INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED,"유효하지 않은 토큰입니다."),
     BAD_REQUEST(HttpStatus.BAD_REQUEST, "BAD REQUEST"),


### PR DESCRIPTION
어색한 '존재하지 않은 계정입니다.'를 '존재하지 않는 계정입니다.'로 변경

[CB-20]

🔨 Jira 태스크
[CB-185] 어색한 에러메시지 내용 수정


📐 구현한 내용
'존재하지 않은 계정입니다'를 '존재하지 않는 계정입니다'로 변경하였습니다.


🚧 논의 사항




[CB-20]: https://cocobob.atlassian.net/browse/CB-20?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CB-185]: https://cocobob.atlassian.net/browse/CB-185?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ