### PR TITLE
CB-225 [feat]: Provide Dog Breeds Info

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ out/
 !**/src/main/**/out/
 !**/src/test/**/out/
 !**/src/main/resources/application-secret.yml
+!**/src/main/resources/application-cloud.yml
 
 ### NetBeans ###
 /nbproject/private/

--- a/src/main/java/com/pinkdumbell/cocobob/domain/pet/PetController.java
+++ b/src/main/java/com/pinkdumbell/cocobob/domain/pet/PetController.java
@@ -1,5 +1,6 @@
 package com.pinkdumbell.cocobob.domain.pet;
 
+import com.pinkdumbell.cocobob.domain.pet.dto.BreedsInfoResponseDto;
 import com.pinkdumbell.cocobob.domain.pet.dto.PetCreateRequestDto;
 import com.pinkdumbell.cocobob.domain.pet.dto.PetCreateResponseDto;
 import com.pinkdumbell.cocobob.exception.ErrorResponse;
@@ -8,12 +9,10 @@ import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.ModelAttribute;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
+import java.util.List;
 
 @ApiOperation("Pet API")
 @RequestMapping("v1/pets")
@@ -33,5 +32,17 @@ public class PetController {
     @PostMapping("")
     public ResponseEntity<PetCreateResponseDto> register(@ModelAttribute @Valid PetCreateRequestDto requestDto) {
         return ResponseEntity.ok(petService.register(requestDto));
+    }
+    @ApiOperation(value = "provide breeds info", notes = "반려동물 견종 정보 제공")
+    @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "", response = BreedsInfoResponseDto.class),
+            @ApiResponse(code = 400, message = "", response = ErrorResponse.class),
+            @ApiResponse(code = 500, message = "INTERNAL SERVER ERROR", response = ErrorResponse.class)
+
+    })
+    @GetMapping("/breeds")
+    public ResponseEntity<List<BreedsInfoResponseDto>> provideBreedsInfo(){
+
+        return ResponseEntity.ok(petService.provideBreedsInfo());
     }
 }

--- a/src/main/java/com/pinkdumbell/cocobob/domain/pet/PetController.java
+++ b/src/main/java/com/pinkdumbell/cocobob/domain/pet/PetController.java
@@ -31,15 +31,22 @@ public class PetController {
             super(status, code, message, data);
         }
     }
+
+    private class ProvideBreedsResponsClass extends CommonResponseDto<List<BreedsInfoResponseDto>>{
+
+        public ProvideBreedsResponsClass(int status, String code, String message, List<BreedsInfoResponseDto> data) {
+            super(status, code, message, data);
+        }
+    }
     @ApiOperation(value = "register pet", notes = "반려동물 등록")
     @ApiResponses(value = {
-            @ApiResponse(code = 200, message = "", response = PetCreateResponseDto.class),
+            @ApiResponse(code = 200, message = "", response = RegisterResponsClass.class),
             @ApiResponse(code = 400, message = "", response = ErrorResponse.class),
             @ApiResponse(code = 500, message = "INTERNAL SERVER ERROR", response = ErrorResponse.class)
 
     })
     @PostMapping("")
-    public ResponseEntity<CommonResponseDto> register(@ModelAttribute @Valid PetCreateRequestDto requestDto) {
+    public ResponseEntity<RegisterResponsClass> register(@ModelAttribute @Valid PetCreateRequestDto requestDto) {
 
         return ResponseEntity.ok(new RegisterResponsClass(HttpStatus.OK.value(),
             "SUCCESS REGISTER",
@@ -54,8 +61,11 @@ public class PetController {
 
     })
     @GetMapping("/breeds")
-    public ResponseEntity<List<BreedsInfoResponseDto>> provideBreedsInfo(){
+    public ResponseEntity<ProvideBreedsResponsClass> provideBreedsInfo(){
 
-        return ResponseEntity.ok(petService.provideBreedsInfo());
+        return ResponseEntity.ok(new ProvideBreedsResponsClass(HttpStatus.OK.value(),
+                "SUCCESS PROVIDE BREEDS",
+                "반려 견종 가져오기 처리 성공",
+                petService.provideBreedsInfo()));
     }
 }

--- a/src/main/java/com/pinkdumbell/cocobob/domain/pet/PetService.java
+++ b/src/main/java/com/pinkdumbell/cocobob/domain/pet/PetService.java
@@ -2,6 +2,7 @@ package com.pinkdumbell.cocobob.domain.pet;
 
 import com.pinkdumbell.cocobob.domain.common.ImageService;
 import com.pinkdumbell.cocobob.domain.pet.breed.BreedRepository;
+import com.pinkdumbell.cocobob.domain.pet.dto.BreedsInfoResponseDto;
 import com.pinkdumbell.cocobob.domain.pet.dto.PetCreateRequestDto;
 import com.pinkdumbell.cocobob.domain.pet.dto.PetCreateResponseDto;
 import com.pinkdumbell.cocobob.domain.pet.image.PetImage;
@@ -11,6 +12,9 @@ import com.pinkdumbell.cocobob.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
 @Service
@@ -42,5 +46,16 @@ public class PetService {
                     imageService.resizeImage(requestDto.getPetImage(), RESIZE_TARGET_WIDTH)));
         }
         return new PetCreateResponseDto(pet);
+    }
+
+    @Transactional
+    public List<BreedsInfoResponseDto> provideBreedsInfo(){
+
+        List<BreedsInfoResponseDto> breedsList = breedRepository.findAll().stream()
+                .map(breed ->
+                    new BreedsInfoResponseDto(breed.getId(), breed.getName(), breed.getSize().toString())
+                ).collect(Collectors.toList());
+
+        return breedsList;
     }
 }

--- a/src/main/java/com/pinkdumbell/cocobob/domain/pet/dto/BreedsInfoResponseDto.java
+++ b/src/main/java/com/pinkdumbell/cocobob/domain/pet/dto/BreedsInfoResponseDto.java
@@ -1,0 +1,13 @@
+package com.pinkdumbell.cocobob.domain.pet.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class BreedsInfoResponseDto {
+
+    private Long id;
+    private String name;
+    private String  size;
+}

--- a/src/test/java/com/pinkdumbell/cocobob/domain/pet/PetControllerTest.java
+++ b/src/test/java/com/pinkdumbell/cocobob/domain/pet/PetControllerTest.java
@@ -142,4 +142,13 @@ class PetControllerTest {
                 .andExpect(jsonPath("$.petId").value(1L))
                 .andExpect(status().isOk());
     }
+
+    @Test
+    @WithMockUser("USER")
+    @DisplayName("사용자에 요청을 통해서 DB에 기록된 반려견 정보 제공")
+    void provideBreedsInfo() throws Exception{
+        mvc.perform(get("/v1/pets/breeds")).
+                andExpect(status().is2xxSuccessful())
+                .andDo(print());
+    }
 }


### PR DESCRIPTION

[CB-123]

🔨 Jira 태스크
[CB-225]
반려동물 견종 정보를 제공하는 API를 추가하였습니다. 호출시 응답으로 List 형태로 견종, 사이즈, 견종Id를 응답 받게 됩니다.
현재 응답 방식이 통일되지 않아 추후펫 서비스 머지 후 통일 시킨 것과 머지시킬 필요성이 보여집니다.
추가적으로 테스트 코드와 swagger 명세도 작성하였으나, 리스트 형식으로 swagger 표기 방식을 몰라 리스트에 담기는 BreedsInfoResponseDto로 표기하였습니다.


📐 구현한 내용
- 반려동물 견종 정보 제공 API
- test코드 작성
- swagger 명세서 작성


🚧 논의 사항
- 통일 응답 형식 변경
- swagger에서 제공하는 파라미터 형식에서 List<Object> 표현 방법 
- 머지 후에 브랜치 삭제 부탁드립니다.


[CB-123]: https://cocobob.atlassian.net/browse/CB-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CB-225]: https://cocobob.atlassian.net/browse/CB-225?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ