### PR TITLE
Cb 225 반려동물 견종 api 없음

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ out/
 !**/src/main/**/out/
 !**/src/test/**/out/
 !**/src/main/resources/application-secret.yml
+!**/src/main/resources/application-cloud.yml
 
 ### NetBeans ###
 /nbproject/private/

--- a/src/main/java/com/pinkdumbell/cocobob/common/AwsS3Service.java
+++ b/src/main/java/com/pinkdumbell/cocobob/common/AwsS3Service.java
@@ -1,4 +1,4 @@
-package com.pinkdumbell.cocobob.domain.common;
+package com.pinkdumbell.cocobob.common;
 
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.CannedAccessControlList;

--- a/src/main/java/com/pinkdumbell/cocobob/common/ImageService.java
+++ b/src/main/java/com/pinkdumbell/cocobob/common/ImageService.java
@@ -1,4 +1,4 @@
-package com.pinkdumbell.cocobob.domain.common;
+package com.pinkdumbell.cocobob.common;
 
 import com.pinkdumbell.cocobob.exception.CustomException;
 import com.pinkdumbell.cocobob.exception.ErrorCode;

--- a/src/main/java/com/pinkdumbell/cocobob/common/dto/CommonResponseDto.java
+++ b/src/main/java/com/pinkdumbell/cocobob/common/dto/CommonResponseDto.java
@@ -1,0 +1,20 @@
+package com.pinkdumbell.cocobob.common.dto;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Builder
+@Getter
+
+public class CommonResponseDto<T> {
+
+    private final int status;
+    private final String code;
+    private final String message;
+    private final T data;
+
+
+}

--- a/src/main/java/com/pinkdumbell/cocobob/config/SecurityConfig.java
+++ b/src/main/java/com/pinkdumbell/cocobob/config/SecurityConfig.java
@@ -42,6 +42,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
     @Override
     protected void configure(HttpSecurity http) throws Exception {
         http.httpBasic().disable() // rest api이므로 기본설정 미사용
+                .cors().and()
             .csrf().disable() // rest api이므로 csrf 보안 미사용
             .formLogin().disable().sessionManagement()
             .sessionCreationPolicy(SessionCreationPolicy.STATELESS) // jwt로 인증하므로 세션 미사용
@@ -53,9 +54,9 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
             .antMatchers("/manager").hasRole("USER")
             .anyRequest().authenticated().and()
             .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider),
-                UsernamePasswordAuthenticationFilter.class); // jwt 인가 필터 추가
-        http.addFilterBefore(new JwtExceptionFilter(),
-            JwtAuthenticationFilter.class); //jwt 토큰 만료 필터
+                UsernamePasswordAuthenticationFilter.class)
+            .addFilterBefore(new JwtExceptionFilter(),
+                JwtAuthenticationFilter.class); // jwt 인가 필터 추가
     }
 
 

--- a/src/main/java/com/pinkdumbell/cocobob/domain/auth/JwtTokenProvider.java
+++ b/src/main/java/com/pinkdumbell/cocobob/domain/auth/JwtTokenProvider.java
@@ -1,5 +1,9 @@
 package com.pinkdumbell.cocobob.domain.auth;
 
+import com.pinkdumbell.cocobob.domain.user.User;
+import com.pinkdumbell.cocobob.domain.user.UserRepository;
+import com.pinkdumbell.cocobob.exception.CustomException;
+import com.pinkdumbell.cocobob.exception.ErrorCode;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jws;
@@ -9,6 +13,7 @@ import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.SignatureException;
 import java.util.Base64;
 import java.util.Date;
+import java.util.Optional;
 import javax.annotation.PostConstruct;
 import javax.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
@@ -23,6 +28,7 @@ import org.springframework.stereotype.Component;
 public class JwtTokenProvider {
 
     private final UserDetailService userDetailService;
+    private final UserRepository userRepository;
     @Value("${spring.jwt.secretKey}")
     private String secretKey;
 
@@ -68,8 +74,21 @@ public class JwtTokenProvider {
 
     public String getUserEmail(String token) {
         try {
-            return Jwts.parser().setSigningKey(secretKey).parseClaimsJws(token).getBody()
-                .getSubject(); //토큰 속 이메일 claim
+            String userEmail = Jwts.parser().setSigningKey(secretKey).parseClaimsJws(token)
+                .getBody()
+                .getSubject();
+
+            User user = userRepository.findByEmail(userEmail).orElseThrow(() -> {
+                throw new JwtException("회원가입 되지 않은 유저 입니다.");
+            });
+
+            if (user.getRefreshToken() != null) {
+                return userEmail; //토큰 속 이메일 claim
+            } else {
+                throw new JwtException("로그아웃된 계정입니다.");
+            }
+
+
         } catch (ExpiredJwtException e) {
             return e.getClaims().getSubject();
         }
@@ -87,11 +106,12 @@ public class JwtTokenProvider {
             throw new JwtException("유효하지 않은 토큰");
         } catch (ExpiredJwtException e) {
             throw new JwtException("토큰 기한 만료");
-        } catch(SignatureException e){
-            throw new JwtException("사용자 인증 실패");
+        } catch (SignatureException e) {
+            throw new JwtException("잘못 서명된 토큰");
         } catch (Exception e) {
-            return false;
+            throw new JwtException("유효하지 않은 토큰");
         }
+
 
     }
 

--- a/src/main/java/com/pinkdumbell/cocobob/domain/auth/dto/JwtExceptionResponse.java
+++ b/src/main/java/com/pinkdumbell/cocobob/domain/auth/dto/JwtExceptionResponse.java
@@ -3,6 +3,7 @@ package com.pinkdumbell.cocobob.domain.auth.dto;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 import org.springframework.http.HttpStatus;
@@ -10,8 +11,11 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 @Getter
 @Setter
+@Builder
 public class JwtExceptionResponse {
-    private final String message;
+    private final int status;
+    private final String code;
+    private final String messages;
     private final HttpStatus httpStatus;
 
     public String convertToJson() throws JsonProcessingException {

--- a/src/main/java/com/pinkdumbell/cocobob/domain/auth/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/pinkdumbell/cocobob/domain/auth/filter/JwtAuthenticationFilter.java
@@ -1,6 +1,7 @@
 package com.pinkdumbell.cocobob.domain.auth.filter;
 
 import com.pinkdumbell.cocobob.domain.auth.JwtTokenProvider;
+import com.pinkdumbell.cocobob.exception.CustomException;
 import io.jsonwebtoken.JwtException;
 import java.io.IOException;
 import javax.servlet.FilterChain;
@@ -30,7 +31,7 @@ public class JwtAuthenticationFilter extends GenericFilter {
                 SecurityContextHolder.getContext().setAuthentication(auth);
             }
         } catch (JwtException e) {
-            throw new JwtException(e.getMessage());
+            throw e;
         }
 
         chain.doFilter(request, response);

--- a/src/main/java/com/pinkdumbell/cocobob/domain/auth/filter/JwtExceptionFilter.java
+++ b/src/main/java/com/pinkdumbell/cocobob/domain/auth/filter/JwtExceptionFilter.java
@@ -1,6 +1,8 @@
 package com.pinkdumbell.cocobob.domain.auth.filter;
 
+import com.pinkdumbell.cocobob.common.dto.CommonResponseDto;
 import com.pinkdumbell.cocobob.domain.auth.dto.JwtExceptionResponse;
+import com.pinkdumbell.cocobob.exception.CustomException;
 import io.jsonwebtoken.JwtException;
 import java.io.IOException;
 import javax.servlet.FilterChain;
@@ -29,8 +31,14 @@ public class JwtExceptionFilter extends OncePerRequestFilter {
         response.setStatus(status.value());
         response.setContentType("application/json; charset=UTF-8");
 
-        JwtExceptionResponse jwtExceptionResponse = new JwtExceptionResponse(ex.getMessage(),
-            HttpStatus.UNAUTHORIZED);
+        JwtExceptionResponse jwtExceptionResponse = JwtExceptionResponse.builder().
+            status(401).
+            httpStatus(HttpStatus.UNAUTHORIZED).
+            code("INVALID ACCESS TOKEN").
+            messages(ex.getMessage()).
+            build();
+
         response.getWriter().write(jwtExceptionResponse.convertToJson());
+
     }
 }

--- a/src/main/java/com/pinkdumbell/cocobob/domain/pet/PetController.java
+++ b/src/main/java/com/pinkdumbell/cocobob/domain/pet/PetController.java
@@ -1,6 +1,7 @@
 package com.pinkdumbell.cocobob.domain.pet;
 
 import com.pinkdumbell.cocobob.domain.pet.dto.BreedsInfoResponseDto;
+import com.pinkdumbell.cocobob.common.dto.CommonResponseDto;
 import com.pinkdumbell.cocobob.domain.pet.dto.PetCreateRequestDto;
 import com.pinkdumbell.cocobob.domain.pet.dto.PetCreateResponseDto;
 import com.pinkdumbell.cocobob.exception.ErrorResponse;
@@ -30,8 +31,13 @@ public class PetController {
 
     })
     @PostMapping("")
-    public ResponseEntity<PetCreateResponseDto> register(@ModelAttribute @Valid PetCreateRequestDto requestDto) {
-        return ResponseEntity.ok(petService.register(requestDto));
+    public ResponseEntity<CommonResponseDto<PetCreateResponseDto>> register(@ModelAttribute @Valid PetCreateRequestDto requestDto) {
+        return ResponseEntity.ok(CommonResponseDto.<PetCreateResponseDto>builder().
+            status(200).
+            code("SUCESS REGISTER").
+            message("회원가입 정상처리").
+            data(petService.register(requestDto)).
+            build());
     }
     @ApiOperation(value = "provide breeds info", notes = "반려동물 견종 정보 제공")
     @ApiResponses(value = {

--- a/src/main/java/com/pinkdumbell/cocobob/domain/pet/PetController.java
+++ b/src/main/java/com/pinkdumbell/cocobob/domain/pet/PetController.java
@@ -1,5 +1,6 @@
 package com.pinkdumbell.cocobob.domain.pet;
 
+import com.pinkdumbell.cocobob.domain.pet.dto.BreedsInfoResponseDto;
 import com.pinkdumbell.cocobob.domain.pet.dto.PetCreateRequestDto;
 import com.pinkdumbell.cocobob.domain.pet.dto.PetCreateResponseDto;
 import com.pinkdumbell.cocobob.exception.ErrorResponse;
@@ -8,12 +9,10 @@ import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.ModelAttribute;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
+import java.util.List;
 
 @ApiOperation("Pet API")
 @RequestMapping("v1/pets")
@@ -33,5 +32,17 @@ public class PetController {
     @PostMapping("")
     public ResponseEntity<PetCreateResponseDto> register(@ModelAttribute @Valid PetCreateRequestDto requestDto) {
         return ResponseEntity.ok(petService.register(requestDto));
+    }
+    @ApiOperation(value = "provide breeds info", notes = "반려동물 견종 정보 제공")
+    @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "", response = BreedsInfoResponseDto.class),
+            @ApiResponse(code = 400, message = "", response = ErrorResponse.class),
+            @ApiResponse(code = 500, message = "INTERNAL SERVER ERROR", response = ErrorResponse.class)
+
+    })
+    @GetMapping("/breeds")
+    public ResponseEntity<List<BreedsInfoResponseDto>> provideBreedsInfo(){
+
+        return ResponseEntity.ok(petService.provideBreedsInfo());
     }
 }

--- a/src/main/java/com/pinkdumbell/cocobob/domain/pet/PetService.java
+++ b/src/main/java/com/pinkdumbell/cocobob/domain/pet/PetService.java
@@ -2,6 +2,7 @@ package com.pinkdumbell.cocobob.domain.pet;
 
 import com.pinkdumbell.cocobob.domain.common.ImageService;
 import com.pinkdumbell.cocobob.domain.pet.breed.BreedRepository;
+import com.pinkdumbell.cocobob.domain.pet.dto.BreedsInfoResponseDto;
 import com.pinkdumbell.cocobob.domain.pet.dto.PetCreateRequestDto;
 import com.pinkdumbell.cocobob.domain.pet.dto.PetCreateResponseDto;
 import com.pinkdumbell.cocobob.domain.pet.image.PetImage;
@@ -11,6 +12,9 @@ import com.pinkdumbell.cocobob.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
 @Service
@@ -42,5 +46,16 @@ public class PetService {
                     imageService.resizeImage(requestDto.getPetImage(), RESIZE_TARGET_WIDTH)));
         }
         return new PetCreateResponseDto(pet);
+    }
+
+    @Transactional
+    public List<BreedsInfoResponseDto> provideBreedsInfo(){
+
+        List<BreedsInfoResponseDto> breedsList = breedRepository.findAll().stream()
+                .map(breed ->
+                    new BreedsInfoResponseDto(breed.getId(), breed.getName(), breed.getSize().toString())
+                ).collect(Collectors.toList());
+
+        return breedsList;
     }
 }

--- a/src/main/java/com/pinkdumbell/cocobob/domain/pet/PetService.java
+++ b/src/main/java/com/pinkdumbell/cocobob/domain/pet/PetService.java
@@ -1,6 +1,6 @@
 package com.pinkdumbell.cocobob.domain.pet;
 
-import com.pinkdumbell.cocobob.domain.common.ImageService;
+import com.pinkdumbell.cocobob.common.ImageService;
 import com.pinkdumbell.cocobob.domain.pet.breed.BreedRepository;
 import com.pinkdumbell.cocobob.domain.pet.dto.BreedsInfoResponseDto;
 import com.pinkdumbell.cocobob.domain.pet.dto.PetCreateRequestDto;

--- a/src/main/java/com/pinkdumbell/cocobob/domain/pet/dto/BreedsInfoResponseDto.java
+++ b/src/main/java/com/pinkdumbell/cocobob/domain/pet/dto/BreedsInfoResponseDto.java
@@ -1,0 +1,13 @@
+package com.pinkdumbell.cocobob.domain.pet.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class BreedsInfoResponseDto {
+
+    private Long id;
+    private String name;
+    private String  size;
+}

--- a/src/main/java/com/pinkdumbell/cocobob/domain/user/UserController.java
+++ b/src/main/java/com/pinkdumbell/cocobob/domain/user/UserController.java
@@ -2,6 +2,7 @@ package com.pinkdumbell.cocobob.domain.user;
 
 import com.pinkdumbell.cocobob.domain.auth.dto.TokenRequestDto;
 import com.pinkdumbell.cocobob.domain.auth.dto.TokenResponseDto;
+import com.pinkdumbell.cocobob.common.dto.CommonResponseDto;
 import com.pinkdumbell.cocobob.domain.user.dto.EmailDuplicationCheckResponseDto;
 import com.pinkdumbell.cocobob.domain.user.dto.UserCreateRequestDto;
 import com.pinkdumbell.cocobob.domain.user.dto.UserCreateResponseDto;
@@ -11,7 +12,6 @@ import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -30,13 +30,18 @@ public class UserController {
 
     @ApiOperation(value = "signup", notes = "서비스 자체 회원가입")
     @ApiResponses(value = {
-        @ApiResponse(code = 200, message = "", response = UserCreateResponseDto.class),
+        @ApiResponse(code = 200, message = "", response = CommonResponseDto.class),
         @ApiResponse(code = 500, message = "INTERNAL SERVER ERROR")
     })
     @PostMapping("/new")
-    public ResponseEntity<UserCreateResponseDto> signup(
+    public ResponseEntity<CommonResponseDto<UserCreateResponseDto>> signup(
         @RequestBody @Valid UserCreateRequestDto requestDto) {
-        return ResponseEntity.ok(userService.signup(requestDto));
+        return ResponseEntity.ok(CommonResponseDto.<UserCreateResponseDto>builder().
+            status(200).
+            code("SUCCESS SIGNUP").
+            message("회원가입 정상처리").
+            data(userService.signup(requestDto)).
+            build());
     }
 
 
@@ -46,43 +51,78 @@ public class UserController {
         @ApiResponse(code = 409, message = "해당 이메일을 가진 사용자가 존재합니다")
     })
     @GetMapping("/email")
-    public ResponseEntity<EmailDuplicationCheckResponseDto> checkEmailDuplicated(
+    public ResponseEntity<CommonResponseDto<EmailDuplicationCheckResponseDto>> checkEmailDuplicated(
         @RequestParam("email") String email) {
-        return ResponseEntity.ok(userService.checkEmailDuplicated(email));
+        return ResponseEntity.ok(CommonResponseDto.<EmailDuplicationCheckResponseDto>builder().
+            status(200).
+            code("SUCCESS CHECK EMAIL").
+            message("중복 이메일 확인").
+            data(userService.checkEmailDuplicated(email)).
+            build());
     }
 
     @ApiOperation(value = "Login", notes = "서비스 자체 로그인")
     @ApiResponses(value = {
-        @ApiResponse(code = 200, message = "", response = UserLoginResponseDto.class),
+        @ApiResponse(code = 200, message = "", response = CommonResponseDto.class),
         @ApiResponse(code = 404, message = "USER_NOT_FOUND"),
         @ApiResponse(code = 403, message = "INVALID_PASSWORD")
     })
     @PostMapping("")
-    public ResponseEntity<UserLoginResponseDto> login(@RequestBody UserLoginRequestDto requestDto) {
-        return ResponseEntity.ok(userService.login(requestDto));
+    public ResponseEntity<CommonResponseDto<UserLoginResponseDto>> login(@RequestBody UserLoginRequestDto requestDto) {
+        return ResponseEntity.ok(CommonResponseDto.<UserLoginResponseDto>builder().
+            status(200).
+            code("SUCCESS LOGIN").
+            message("로그인 정상처리").
+            data(userService.login(requestDto)).
+            build());
     }
+
     @ApiOperation(value = "Reissue", notes = "refresh Token을 통한 Token 재발행")
     @ApiResponses(value = {
-        @ApiResponse(code = 200, message = "", response = TokenResponseDto.class),
+        @ApiResponse(code = 200, message = "", response = CommonResponseDto.class),
         @ApiResponse(code = 401, message = "UNAUTHORIZED"),
     })
     @GetMapping("/token")
-    public ResponseEntity<TokenResponseDto> reissue(
-        @RequestHeader("accessToken") String accessToken,
-        @RequestHeader("refreshToken") String refreshToken) {
+    public ResponseEntity<CommonResponseDto<TokenResponseDto>> reissue(
+        @RequestHeader("authorization") String accessToken,
+        @RequestHeader("refresh-token") String refreshToken) {
         TokenRequestDto tokenRequestDto = TokenRequestDto.builder()
             .accessToken(accessToken)
             .refreshToken(refreshToken)
             .build();
 
         try {
-            return ResponseEntity.ok(userService.reissue(tokenRequestDto));
-        } catch (CustomException | JwtException e){
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+            return ResponseEntity.ok(CommonResponseDto.<TokenResponseDto>builder()
+                .status(201).code("SUCCESS REISSUE")
+                .message("토큰이 재발행 정상처리")
+                .data(userService.reissue(tokenRequestDto))
+                .build());
+        } catch (CustomException | JwtException e) {
+            throw e;
         }
-
-
     }
 
+    @ApiOperation(value = "Logout", notes = "로그아웃")
+    @ApiResponses(value = {
+        @ApiResponse(code = 200, message = "로그아웃 처리완료 되었습니다.", response = CommonResponseDto.class),
+        @ApiResponse(code = 401, message = "UNAUTHORIZED"),
+    })
+    @DeleteMapping("")
+    public ResponseEntity<CommonResponseDto> logout(@RequestHeader("Authorization") String accessToken) {
+
+        try {
+            userService.logout(accessToken);
+        } catch (CustomException e) {
+            throw e;
+        }
+       
+
+        return ResponseEntity.ok(CommonResponseDto.builder()
+            .status(200).
+            code("Logout Success").
+            message("로그아웃 처리완료 되었습니다.").
+            data(null).
+            build());
+    }
 
 }

--- a/src/main/java/com/pinkdumbell/cocobob/domain/user/dto/UserLoginRequestDto.java
+++ b/src/main/java/com/pinkdumbell/cocobob/domain/user/dto/UserLoginRequestDto.java
@@ -11,7 +11,6 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class UserLoginRequestDto {
 
-    private String username;
     private String email;
     private String password;
 

--- a/src/main/java/com/pinkdumbell/cocobob/domain/user/dto/UserLoginResponseDto.java
+++ b/src/main/java/com/pinkdumbell/cocobob/domain/user/dto/UserLoginResponseDto.java
@@ -12,7 +12,7 @@ public class UserLoginResponseDto {
     private final String email;
     private final String username;
     private final String role;
-    private final String accessToken;
+    private final String authorization;
     private final String refreshToken;
 
     public UserLoginResponseDto(User entity, String  accessToken,String refreshToken) {
@@ -20,7 +20,7 @@ public class UserLoginResponseDto {
         this.email = entity.getEmail();
         this.username = entity.getUsername();
         this.role = entity.getRole().toString();
-        this.accessToken = accessToken;
+        this.authorization = accessToken;
         this.refreshToken = refreshToken;
     }
 }

--- a/src/main/java/com/pinkdumbell/cocobob/exception/ErrorCode.java
+++ b/src/main/java/com/pinkdumbell/cocobob/exception/ErrorCode.java
@@ -10,13 +10,15 @@ public enum ErrorCode {
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 계정입니다."),
     BREED_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 견종입니다."),
     INVALID_PASSWORD(HttpStatus.FORBIDDEN, "비밀번호가 일치하지 않습니다."),
-    INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED,"유효하지 않은 토큰입니다."),
+    INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 Refresh 토큰입니다."),
     BAD_REQUEST(HttpStatus.BAD_REQUEST, "BAD REQUEST"),
     NOT_IMAGE(HttpStatus.BAD_REQUEST, "올바른 이미지 파일이 아닙니다."),
     DUPLICATED_EMAIL(HttpStatus.CONFLICT, "해당 이메일을 가진 사용자가 존재합니다."),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "INTERNAL SERVER ERROR"),
     FAIL_TO_RESIZE_IMAGE(HttpStatus.INTERNAL_SERVER_ERROR, "이미지 리사이징을 실패했습니다."),
-    FAIL_TO_UPLOAD_IMAGE(HttpStatus.INTERNAL_SERVER_ERROR, "s3 버킷에 이미지 업로드를 실패했습니다.");
+    FAIL_TO_UPLOAD_IMAGE(HttpStatus.INTERNAL_SERVER_ERROR, "s3 버킷에 이미지 업로드를 실패했습니다."),
+    INVALID_LOGOUT_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 로그아웃 요청입니다."),
+    INVALID_ACCESS_AFTER_LOGOUT(HttpStatus.BAD_REQUEST, "로그아웃된 유저 입니다."),;
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/test/java/com/pinkdumbell/cocobob/domain/pet/PetControllerTest.java
+++ b/src/test/java/com/pinkdumbell/cocobob/domain/pet/PetControllerTest.java
@@ -142,4 +142,13 @@ class PetControllerTest {
                 .andExpect(jsonPath("$.petId").value(1L))
                 .andExpect(status().isOk());
     }
+
+    @Test
+    @WithMockUser("USER")
+    @DisplayName("사용자에 요청을 통해서 DB에 기록된 반려견 정보 제공")
+    void provideBreedsInfo() throws Exception{
+        mvc.perform(get("/v1/pets/breeds")).
+                andExpect(status().is2xxSuccessful())
+                .andDo(print());
+    }
 }

--- a/src/test/java/com/pinkdumbell/cocobob/domain/pet/PetControllerTest.java
+++ b/src/test/java/com/pinkdumbell/cocobob/domain/pet/PetControllerTest.java
@@ -139,7 +139,7 @@ class PetControllerTest {
                         .param("age", String.valueOf(age))
                         .param("bodyWeight", String.valueOf(bodyWeight))
                 )
-                .andExpect(jsonPath("$.petId").value(1L))
+                .andExpect(jsonPath("$.data.petId").value(1L))
                 .andExpect(status().isOk());
     }
 

--- a/src/test/java/com/pinkdumbell/cocobob/domain/user/UserControllerTest.java
+++ b/src/test/java/com/pinkdumbell/cocobob/domain/user/UserControllerTest.java
@@ -98,8 +98,8 @@ class UserControllerTest {
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(new ObjectMapper().writeValueAsString(userLoginRequestDto)))
             .andExpect(status().is2xxSuccessful())
-            .andExpect(jsonPath("$.accessToken", notNullValue())) //토큰 값들이 정상적으로 전달되었는지
-            .andExpect(jsonPath("$.refreshToken", notNullValue()))
+            .andExpect(jsonPath("$.data.authorization", notNullValue())) //토큰 값들이 정상적으로 전달되었는지
+            .andExpect(jsonPath("$.data.refreshToken", notNullValue()))
             .andDo(print());
     }
 
@@ -149,11 +149,10 @@ class UserControllerTest {
             .build();
 
         UserLoginResponseDto userLoginResponseDto = userService.login(userLoginRequestDto);
-
         //EXECUTE & EXPECT
         // 로그인 후 접근 가능한 페이지 접근
         mvc.perform(get("/hello")
-                .header("Authorization", "Bearer " + userLoginResponseDto.getAccessToken()))
+                .header("Authorization", "Bearer " + userLoginResponseDto.getAuthorization()))
             .andExpect(status().is2xxSuccessful())
             .andDo(print());
     }
@@ -183,15 +182,8 @@ class UserControllerTest {
         UserLoginResponseDto userLoginResponseDto = userService.login(userLoginRequestDto);
 
         // 유효하지 않은 토큰 생성
-        Claims claims = Jwts.claims().setSubject(email);
-        Date now = new Date();
 
-        String invalidToken = Jwts.builder()
-            .setClaims(claims)
-            .setIssuedAt(now)
-            .setExpiration(new Date(now.getTime())) //만료시간을 지금 즉시로 생성
-            .signWith(SignatureAlgorithm.HS256, secretKey)
-            .compact();
+        String invalidToken = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0QHRlc3QuY29tIiwiaWF0IjoxNjU4ODIzMDY3LCJleHAiOjE2NTg4MjQ4Njd9.EzRbUv390S78fQbbAHE87bA-M5QOIpZWQTAFD3z2Zrk";
 
         //EXECUTE & EXPECT
         // 로그인 후 접근 가능한 페이지 접근
@@ -225,15 +217,14 @@ class UserControllerTest {
 
         UserLoginResponseDto userLoginResponseDto = userService.login(userLoginRequestDto);
 
-
         //EXECUTE & EXPECT
         // 토큰 재발행
         mvc.perform(get("/v1/users/token")
-                .header("accessToken", "Bearer " + userLoginResponseDto.getAccessToken())
-                .header("refreshToken", "Bearer " + userLoginResponseDto.getRefreshToken())
+                .header("authorization", "Bearer " + userLoginResponseDto.getAuthorization())
+                .header("refresh-token", "Bearer " + userLoginResponseDto.getRefreshToken())
             ).andExpect(status().is2xxSuccessful())
-            .andExpect(jsonPath("$.accessToken", notNullValue())) //토큰 값들이 정상적으로 전달되었는지
-            .andExpect(jsonPath("$.refreshToken", notNullValue()))
+            .andExpect(jsonPath("$.data.accessToken", notNullValue())) //토큰 값들이 정상적으로 전달되었는지
+            .andExpect(jsonPath("$.data.refreshToken", notNullValue()))
             .andDo(print());
     }
 
@@ -262,19 +253,13 @@ class UserControllerTest {
         UserLoginResponseDto userLoginResponseDto = userService.login(userLoginRequestDto);
 
         //유효하지 않은 리프레시 토큰 생성
-        Date now = new Date();
-        String invalidRefreshToken = Jwts.builder()
-            .setIssuedAt(now)
-            .setExpiration(new Date(now.getTime() + 10000)) //임의로 유효기간 10초로 설정
-            .signWith(SignatureAlgorithm.HS256, secretKey)
-            .compact();
-
+        String invalidRefreshToken = "eyJhbGciOiJIUzI1NiJ9.eyJpYXQiOjE2NTg4Mjc0NTQsImV4cCI6MTY1OTQzMjI1NH0.jlFgztcUQ1gMAxQpdpaf6drx-JBUsSGHCgr1FNFkWos";
 
         //EXECUTE & EXPECT
         // 토큰 재발행
         mvc.perform(get("/v1/users/token")
-                .header("accessToken", "Bearer " + userLoginResponseDto.getAccessToken())
-                .header("refreshToken", "Bearer " + invalidRefreshToken)
+                .header("authorization", "Bearer " + userLoginResponseDto.getAuthorization())
+                .header("refresh-token", "Bearer " + invalidRefreshToken)
             ).andExpect(status().is4xxClientError())
             .andDo(print());
     }
@@ -307,17 +292,146 @@ class UserControllerTest {
         Date now = new Date();
         String invalidRefreshToken = Jwts.builder()
             .setIssuedAt(now)
-            .setExpiration(new Date(now.getTime())) //만료된 토큰
+            .setExpiration(new Date(now.getTime() + 1000)) //만료된 토큰
             .signWith(SignatureAlgorithm.HS256, secretKey)
             .compact();
-
 
         //EXECUTE & EXPECT
         // 토큰 재발행
         mvc.perform(get("/v1/users/token")
-                .header("accessToken", "Bearer " + userLoginResponseDto.getAccessToken())
-                .header("refreshToken", "Bearer " + invalidRefreshToken)
+                .header("authorization", "Bearer " + userLoginResponseDto.getAuthorization())
+                .header("refresh-token", "Bearer " + invalidRefreshToken)
             ).andExpect(status().is4xxClientError())
+            .andDo(print());
+    }
+
+    @Test
+    @DisplayName("다른 환경에서 로그인 시 로그인후 기존 로그인 해제")
+    void 중복_로그인_확인() throws Exception {
+        //SET UP
+        final String username = "TESTER";
+        final String email = "test@test.com";
+        final String password = "password";
+
+        //회원가입
+        UserCreateRequestDto requestDto = UserCreateRequestDto.builder()
+            .username(username)
+            .email(email)
+            .password(password)
+            .build();
+        UserCreateResponseDto userCreateResponseDto = userService.signup(requestDto);
+
+        //로그인 요청 정보 초기화
+        UserLoginRequestDto userLoginRequestDto = UserLoginRequestDto.builder()
+            .email(email)
+            .password(password)
+            .build();
+
+        //EXECUTE & EXPECT
+        // 1차 로그인 실행
+        mvc.perform(post("/v1/users")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(new ObjectMapper().writeValueAsString(userLoginRequestDto)))
+            .andExpect(status().is2xxSuccessful())
+            .andExpect(jsonPath("$.data.authorization", notNullValue())) //토큰 값들이 정상적으로 전달되었는지
+            .andExpect(jsonPath("$.data.refreshToken", notNullValue()))
+            .andDo(print());
+        // 2차 로그인 실행
+        mvc.perform(post("/v1/users")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(new ObjectMapper().writeValueAsString(userLoginRequestDto)))
+            .andExpect(status().is2xxSuccessful())
+            .andExpect(jsonPath("$.data.authorization", notNullValue())) //토큰 값들이 정상적으로 전달되었는지
+            .andExpect(jsonPath("$.data.refreshToken", notNullValue()))
+            .andDo(print());
+    }
+
+    @Test
+    @DisplayName("로그 아웃 후 access token으로 접근")
+    void 로그아웃후_accessToken_접근() throws Exception {
+        //SET UP
+        final String username = "TESTER";
+        final String email = "test@test.com";
+        final String password = "password";
+
+        //회원가입
+        UserCreateRequestDto requestDto = UserCreateRequestDto.builder()
+            .username(username)
+            .email(email)
+            .password(password)
+            .build();
+        UserCreateResponseDto userCreateResponseDto = userService.signup(requestDto);
+
+        //로그인 요청 정보 초기화
+        UserLoginRequestDto userLoginRequestDto = UserLoginRequestDto.builder()
+            .email(email)
+            .password(password)
+            .build();
+
+        UserLoginResponseDto userLoginResponseDto = userService.login(userLoginRequestDto);
+
+        // 로그인 후 접근 가능한 페이지 접근
+        mvc.perform(get("/hello")
+                .header("Authorization", "Bearer " + userLoginResponseDto.getAuthorization()))
+            .andExpect(status().is2xxSuccessful())
+            .andDo(print());
+
+        //EXECUTE & EXPECT
+        //로그 아웃
+        mvc.perform(delete("/v1/users")
+                .header("Authorization", "Bearer " + userLoginResponseDto.getAuthorization()))
+            .andExpect(status().is2xxSuccessful())
+            .andDo(print());
+
+        //로그 아웃 후 재접근
+        mvc.perform(get("/hello")
+                .header("Authorization", "Bearer " + userLoginResponseDto.getAuthorization()))
+            .andExpect(status().is4xxClientError())
+            .andDo(print());
+    }
+
+    @Test
+    @DisplayName("로그 아웃 후 재로그인")
+    void 로그아웃후_재로그인() throws Exception {
+        //SET UP
+        final String username = "TESTER";
+        final String email = "test@test.com";
+        final String password = "password";
+
+        //회원가입
+        UserCreateRequestDto requestDto = UserCreateRequestDto.builder()
+            .username(username)
+            .email(email)
+            .password(password)
+            .build();
+        UserCreateResponseDto userCreateResponseDto = userService.signup(requestDto);
+
+        //로그인 요청 정보 초기화
+        UserLoginRequestDto userLoginRequestDto = UserLoginRequestDto.builder()
+            .email(email)
+            .password(password)
+            .build();
+
+        UserLoginResponseDto userLoginResponseDto = userService.login(userLoginRequestDto);
+
+        // 로그인 후 접근 가능한 페이지 접근
+        mvc.perform(get("/hello")
+                .header("Authorization", "Bearer " + userLoginResponseDto.getAuthorization()))
+            .andExpect(status().is2xxSuccessful())
+            .andDo(print());
+
+        //EXECUTE & EXPECT
+        //로그 아웃
+        mvc.perform(delete("/v1/users")
+                .header("Authorization", "Bearer " + userLoginResponseDto.getAuthorization()))
+            .andExpect(status().is2xxSuccessful())
+            .andDo(print());
+
+        UserLoginResponseDto userLoginResponseDto_retry = userService.login(userLoginRequestDto);
+        //로그인 후 재접근
+        mvc.perform(get("/hello")
+                .header("Authorization", "Bearer " + userLoginResponseDto_retry.getAuthorization()))
+            .andExpect(status().is2xxSuccessful())
             .andDo(print());
     }
 


### PR DESCRIPTION
[CB-123]

🔨 Jira 태스크
[CB-225]
반려동물 견종 정보를 제공하는 API를 추가하였습니다. 호출시 응답으로 List 형태로 견종, 사이즈, 견종Id를 응답 받게 됩니다.
현재 응답 방식이 통일되지 않아 추후펫 서비스 머지 후 통일 시킨 것과 머지시킬 필요성이 보여집니다.
추가적으로 테스트 코드와 swagger 명세도 작성하였으나, 리스트 형식으로 swagger 표기 방식을 몰라 리스트에 담기는 BreedsInfoResponseDto로 표기하였습니다.

📐 구현한 내용

반려동물 견종 정보 제공 API
test코드 작성
swagger 명세서 작성
🚧 논의 사항

통일 응답 형식 변경
swagger에서 제공하는 파라미터 형식에서 List 표현 방법
머지 후에 브랜치 삭제 부탁드립니다.



[CB-123]: https://cocobob.atlassian.net/browse/CB-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CB-225]: https://cocobob.atlassian.net/browse/CB-225?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ