### PR TITLE
CB-252 [feat]: available Authorization Button

### DIFF
--- a/src/main/java/com/pinkdumbell/cocobob/config/SwaggerConfig.java
+++ b/src/main/java/com/pinkdumbell/cocobob/config/SwaggerConfig.java
@@ -2,15 +2,22 @@ package com.pinkdumbell.cocobob.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 import springfox.documentation.builders.ApiInfoBuilder;
 import springfox.documentation.builders.PathSelectors;
 import springfox.documentation.builders.RequestHandlerSelectors;
 import springfox.documentation.service.ApiInfo;
+import springfox.documentation.service.ApiKey;
+import springfox.documentation.service.AuthorizationScope;
+import springfox.documentation.service.SecurityReference;
 import springfox.documentation.spi.DocumentationType;
+import springfox.documentation.spi.service.contexts.SecurityContext;
 import springfox.documentation.spring.web.plugins.Docket;
 
+import java.util.Arrays;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 @Configuration
@@ -19,19 +26,21 @@ public class SwaggerConfig {
 
     private ApiInfo swaggerInfo() {
         return new ApiInfoBuilder().title("Cocobob API Docs")
-            .description("API Docs for CocoBob").build();
+                .description("API Docs for CocoBob").build();
     }
 
     @Bean
     public Docket swaggerApi() {
-        return new Docket(DocumentationType.SWAGGER_2)
-            .consumes(getConsumeContentTypes())
-            .produces(getProduceContentTypes())
-            .apiInfo(swaggerInfo()).select()
-            .apis(RequestHandlerSelectors.basePackage("com.pinkdumbell.cocobob"))
-            .paths(PathSelectors.any())
-            .build()
-            .useDefaultResponseMessages(false);
+        return new Docket(DocumentationType.OAS_30)
+                .securityContexts(Arrays.asList(securityContext()))
+                .securitySchemes(Arrays.asList(apiKey()))
+                .consumes(getConsumeContentTypes())
+                .produces(getProduceContentTypes())
+                .apiInfo(swaggerInfo()).select()
+                .apis(RequestHandlerSelectors.basePackage("com.pinkdumbell.cocobob"))
+                .paths(PathSelectors.any())
+                .build()
+                .useDefaultResponseMessages(false);
     }
 
     private Set<String> getConsumeContentTypes() {
@@ -45,5 +54,22 @@ public class SwaggerConfig {
         Set<String> produces = new HashSet<>();
         produces.add("application/json;charset=UTF-8");
         return produces;
+    }
+
+    private SecurityContext securityContext() {
+        return SecurityContext.builder()
+                .securityReferences(defaultAuth())
+                .build();
+    }
+
+    private List<SecurityReference> defaultAuth() {
+        AuthorizationScope authorizationScope = new AuthorizationScope("global", "accessEverything");
+        AuthorizationScope[] authorizationScopes = new AuthorizationScope[1];
+        authorizationScopes[0] = authorizationScope;
+        return Arrays.asList(new SecurityReference("Authorization", authorizationScopes));
+    }
+
+    private ApiKey apiKey() {
+        return new ApiKey("Authorization", "Authorization", "header");
     }
 }

--- a/src/main/java/com/pinkdumbell/cocobob/domain/pet/PetController.java
+++ b/src/main/java/com/pinkdumbell/cocobob/domain/pet/PetController.java
@@ -52,7 +52,7 @@ public class PetController {
 
         return ResponseEntity.ok(new RegisterResponsClass(HttpStatus.OK.value(),
             "SUCCESS REGISTER",
-            "회원가입 정상처리",
+            "반려동물 등록 정상처리",
             petService.register(loginUserInfo, requestDto)));
     }
     @ApiOperation(value = "provide breeds info", notes = "반려동물 견종 정보 제공")


### PR DESCRIPTION

[CB-252]

🔨 Jira 태스크
[CB-252] [CB-93]


📐 구현한 내용
- Swagger에  Authorization 추가
- 회원가입 정상처리 - > 반려동물 등록 정상처리 : 반려동물 등록 잘못된 message 수정
![화면 캡처 2022-07-31 001905](https://user-images.githubusercontent.com/41332873/181921064-d8176241-54f6-4814-acb6-1f19c90d0873.png)


🚧 논의 사항
Swagger를 통해서 test는 Header에 토큰을 추가할수없어 하지 못하였습니다.
그러나, 이번 수정을 통해서 swgger를 통해서 accessToken을 넣을 수 있게
되면서 swagger를 통해서도 모든 API들을 테스트할 수 있게 하였습니다.
또한, issue에 10년짜리 accessToken을 추가하였으니 해당 토큰을 사용하면은
test용으로 문제 없을 것입니다.



[CB-252]: https://cocobob.atlassian.net/browse/CB-252?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CB-252]: https://cocobob.atlassian.net/browse/CB-252?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CB-93]: https://cocobob.atlassian.net/browse/CB-93?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ