### PR TITLE
[CB-151] BE 엔터티 생성 수정 삭제일자가 없음

### DIFF
--- a/src/main/java/com/pinkdumbell/cocobob/common/BaseEntity.java
+++ b/src/main/java/com/pinkdumbell/cocobob/common/BaseEntity.java
@@ -1,4 +1,4 @@
-package com.pinkdumbell.cocobob.domain.common;
+package com.pinkdumbell.cocobob.common;
 
 import lombok.Getter;
 import org.springframework.data.annotation.CreatedDate;

--- a/src/main/java/com/pinkdumbell/cocobob/config/JpaAuditingConfig.java
+++ b/src/main/java/com/pinkdumbell/cocobob/config/JpaAuditingConfig.java
@@ -1,0 +1,9 @@
+package com.pinkdumbell.cocobob.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@EnableJpaAuditing
+@Configuration
+public class JpaAuditingConfig {
+}

--- a/src/main/java/com/pinkdumbell/cocobob/domain/common/BaseEntity.java
+++ b/src/main/java/com/pinkdumbell/cocobob/domain/common/BaseEntity.java
@@ -1,0 +1,20 @@
+package com.pinkdumbell.cocobob.domain.common;
+
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+    @CreatedDate
+    private LocalDateTime createdAt;
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/pinkdumbell/cocobob/domain/daily/Daily.java
+++ b/src/main/java/com/pinkdumbell/cocobob/domain/daily/Daily.java
@@ -1,5 +1,6 @@
 package com.pinkdumbell.cocobob.domain.daily;
 
+import com.pinkdumbell.cocobob.domain.common.BaseEntity;
 import com.pinkdumbell.cocobob.domain.pet.Pet;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -10,7 +11,7 @@ import java.time.LocalDate;
 @Getter
 @NoArgsConstructor
 @Entity
-public class Daily {
+public class Daily extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "daily_id")

--- a/src/main/java/com/pinkdumbell/cocobob/domain/daily/Daily.java
+++ b/src/main/java/com/pinkdumbell/cocobob/domain/daily/Daily.java
@@ -1,6 +1,6 @@
 package com.pinkdumbell.cocobob.domain.daily;
 
-import com.pinkdumbell.cocobob.domain.common.BaseEntity;
+import com.pinkdumbell.cocobob.common.BaseEntity;
 import com.pinkdumbell.cocobob.domain.pet.Pet;
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/src/main/java/com/pinkdumbell/cocobob/domain/pet/Pet.java
+++ b/src/main/java/com/pinkdumbell/cocobob/domain/pet/Pet.java
@@ -1,6 +1,6 @@
 package com.pinkdumbell.cocobob.domain.pet;
 
-import com.pinkdumbell.cocobob.domain.common.BaseEntity;
+import com.pinkdumbell.cocobob.common.BaseEntity;
 import com.pinkdumbell.cocobob.domain.pet.breed.Breed;
 import com.pinkdumbell.cocobob.domain.pet.image.PetImage;
 import com.pinkdumbell.cocobob.domain.user.User;

--- a/src/main/java/com/pinkdumbell/cocobob/domain/pet/Pet.java
+++ b/src/main/java/com/pinkdumbell/cocobob/domain/pet/Pet.java
@@ -1,5 +1,6 @@
 package com.pinkdumbell.cocobob.domain.pet;
 
+import com.pinkdumbell.cocobob.domain.common.BaseEntity;
 import com.pinkdumbell.cocobob.domain.pet.breed.Breed;
 import com.pinkdumbell.cocobob.domain.pet.image.PetImage;
 import com.pinkdumbell.cocobob.domain.user.User;
@@ -13,7 +14,7 @@ import java.time.LocalDate;
 @Getter
 @NoArgsConstructor
 @Entity
-public class Pet {
+public class Pet extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "pet_id")

--- a/src/main/java/com/pinkdumbell/cocobob/domain/user/User.java
+++ b/src/main/java/com/pinkdumbell/cocobob/domain/user/User.java
@@ -1,6 +1,7 @@
 package com.pinkdumbell.cocobob.domain.user;
 
 import com.pinkdumbell.cocobob.domain.auth.Token;
+import com.pinkdumbell.cocobob.domain.common.BaseEntity;
 import com.pinkdumbell.cocobob.domain.pet.Pet;
 import lombok.Builder;
 import lombok.Getter;
@@ -15,7 +16,7 @@ import java.util.List;
 @NoArgsConstructor
 @Table(name = "\"user\"")
 @Entity
-public class User {
+public class User extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "user_id")

--- a/src/main/java/com/pinkdumbell/cocobob/domain/user/User.java
+++ b/src/main/java/com/pinkdumbell/cocobob/domain/user/User.java
@@ -1,7 +1,7 @@
 package com.pinkdumbell.cocobob.domain.user;
 
 import com.pinkdumbell.cocobob.domain.auth.Token;
-import com.pinkdumbell.cocobob.domain.common.BaseEntity;
+import com.pinkdumbell.cocobob.common.BaseEntity;
 import com.pinkdumbell.cocobob.domain.pet.Pet;
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/resources/db/migration/V5__add_created_updated_at.sql
+++ b/src/main/resources/db/migration/V5__add_created_updated_at.sql
@@ -1,0 +1,8 @@
+alter table user add created_at timestamp;
+alter table user add updated_at timestamp;
+
+alter table pet add created_at timestamp;
+alter table pet add updated_at timestamp;
+
+alter table daily add created_at timestamp;
+alter table daily add updated_at timestamp;

--- a/src/test/java/com/pinkdumbell/cocobob/domain/user/UserRepositoryTest.java
+++ b/src/test/java/com/pinkdumbell/cocobob/domain/user/UserRepositoryTest.java
@@ -1,0 +1,28 @@
+package com.pinkdumbell.cocobob.domain.user;
+
+import com.pinkdumbell.cocobob.config.JpaAuditingConfig;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.assertj.core.api.Assertions;
+
+import java.time.LocalDateTime;
+
+@DataJpaTest
+@Import(JpaAuditingConfig.class)
+public class UserRepositoryTest {
+    @Autowired
+    UserRepository userRepository;
+
+    @Test
+    @DisplayName("사용자 생성 시 생성시간 등록 여부를 테스트한다.")
+    void testAuditing() {
+        LocalDateTime now = LocalDateTime.now();
+        User user = userRepository.save(User.builder().build());
+
+        Assertions.assertThat(user.getCreatedAt()).isAfter(now);
+        Assertions.assertThat(user.getUpdatedAt()).isAfter(now);
+    }
+}


### PR DESCRIPTION
[CB-151]

🔨 Jira 태스크
[CB-151] BE 엔터티 생성 수정 삭제일자가 없음

📐 구현한 내용
- 엔티티의 생성, 수정시간을 담는 BaseEntity 생성
- JpaAuditingConfig 생성 및 JpaAuditing 활성화
- JpaAuditing 테스트

🚧 논의 사항




[CB-151]: https://cocobob.atlassian.net/browse/CB-151?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CB-151]: https://cocobob.atlassian.net/browse/CB-151?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ