### PR TITLE
[CB-257] [BE] 사용자 정보를 가져오는 기능이 필요함

### DIFF
--- a/src/main/java/com/pinkdumbell/cocobob/domain/pet/Pet.java
+++ b/src/main/java/com/pinkdumbell/cocobob/domain/pet/Pet.java
@@ -50,9 +50,6 @@ public class Pet extends BaseEntity {
     @JoinColumn(name = "breed_id")
     private Breed breed;
 
-    @OneToOne(mappedBy = "pet", fetch = FetchType.LAZY)
-    private PetImage petImage;
-
     @Builder
     public Pet(String name,
                PetSex sex,

--- a/src/main/java/com/pinkdumbell/cocobob/domain/pet/dto/SimplePetInfoDto.java
+++ b/src/main/java/com/pinkdumbell/cocobob/domain/pet/dto/SimplePetInfoDto.java
@@ -1,14 +1,18 @@
 package com.pinkdumbell.cocobob.domain.pet.dto;
 
 import com.pinkdumbell.cocobob.domain.pet.Pet;
+import io.swagger.annotations.ApiModelProperty;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
 public class SimplePetInfoDto {
+    @ApiModelProperty(notes = "반려동물 아이디", example = "1")
     private final Long petId;
+    @ApiModelProperty(notes = "반려동물 이름", example = "coco")
     private final String name;
+    @ApiModelProperty(notes = "반려동물 프로필 사진의 썸네일 이미지 경로", example = "https://...")
     private final String thumbnailPath;
 
     public SimplePetInfoDto(Pet entity) {

--- a/src/main/java/com/pinkdumbell/cocobob/domain/pet/dto/SimplePetInfoDto.java
+++ b/src/main/java/com/pinkdumbell/cocobob/domain/pet/dto/SimplePetInfoDto.java
@@ -1,0 +1,19 @@
+package com.pinkdumbell.cocobob.domain.pet.dto;
+
+import com.pinkdumbell.cocobob.domain.pet.Pet;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class SimplePetInfoDto {
+    private final Long petId;
+    private final String name;
+    private final String thumbnailPath;
+
+    public SimplePetInfoDto(Pet entity) {
+        this.petId = entity.getId();
+        this.name = entity.getName();
+        this.thumbnailPath = entity.getThumbnailPath();
+    }
+}

--- a/src/main/java/com/pinkdumbell/cocobob/domain/pet/image/PetImage.java
+++ b/src/main/java/com/pinkdumbell/cocobob/domain/pet/image/PetImage.java
@@ -1,6 +1,7 @@
 package com.pinkdumbell.cocobob.domain.pet.image;
 
 import com.pinkdumbell.cocobob.domain.pet.Pet;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -22,6 +23,7 @@ public class PetImage {
     @JoinColumn(name = "pet_id")
     private Pet pet;
 
+    @Builder
     public PetImage(String path,
                     Pet pet) {
         this.path = path;

--- a/src/main/java/com/pinkdumbell/cocobob/domain/user/User.java
+++ b/src/main/java/com/pinkdumbell/cocobob/domain/user/User.java
@@ -31,7 +31,7 @@ public class User extends BaseEntity {
     @Enumerated(value = EnumType.STRING)
     private AccountType accountType;
 
-    @OneToOne
+    @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "representative_pet_id")
     private Pet representativePet;
     @Enumerated(value = EnumType.STRING)

--- a/src/main/java/com/pinkdumbell/cocobob/domain/user/UserController.java
+++ b/src/main/java/com/pinkdumbell/cocobob/domain/user/UserController.java
@@ -211,6 +211,11 @@ public class UserController {
 
     }
 
+    @ApiOperation(value = "GetUserInfo", notes = "사용자 정보와 함께 등록된 반려동물의 간단한 정보를 가져온다.")
+    @ApiResponses({
+            @ApiResponse(code = 200, message = "GET_USER_INFO_SUCCESS", response = UserGetResponseClass.class),
+            @ApiResponse(code = 404, message = "USER_NOT_FOUND")
+    })
     @GetMapping("")
     public ResponseEntity<UserGetResponseClass> getUserInfo(@LoginUser LoginUserInfo loginUserInfo) {
         return ResponseEntity.ok(new UserGetResponseClass(

--- a/src/main/java/com/pinkdumbell/cocobob/domain/user/UserController.java
+++ b/src/main/java/com/pinkdumbell/cocobob/domain/user/UserController.java
@@ -1,5 +1,6 @@
 package com.pinkdumbell.cocobob.domain.user;
 
+import com.pinkdumbell.cocobob.config.annotation.loginuser.LoginUser;
 import com.pinkdumbell.cocobob.domain.auth.dto.TokenRequestDto;
 import com.pinkdumbell.cocobob.common.dto.CommonResponseDto;
 import com.pinkdumbell.cocobob.domain.auth.dto.TokenResponseDto;
@@ -61,6 +62,12 @@ public class UserController {
         }
     }
 
+    private class UserGetResponseClass extends CommonResponseDto<UserGetResponseDto> {
+        public UserGetResponseClass(int status, String code, String message,
+                UserGetResponseDto data) {
+            super(status, code, message, data);
+        }
+    }
 
     @ApiOperation(value = "signup", notes = "서비스 자체 회원가입")
     @ApiResponses(value = {
@@ -201,6 +208,18 @@ public class UserController {
             message("비밀번호가 성공적으로 변경되었습니다.").
             data(null).
             build());
+
+    }
+
+    @GetMapping("")
+    public ResponseEntity<UserGetResponseClass> getUserInfo(@LoginUser LoginUserInfo loginUserInfo) {
+        return ResponseEntity.ok(new UserGetResponseClass(
+                HttpStatus.OK.value(),
+                "GET_USER_INFO_SUCCESS",
+                "사용자 정보가 성공적으로 반환되었습니다.",
+                userService.getUserInfo(loginUserInfo)
+        ));
+
 
     }
 

--- a/src/main/java/com/pinkdumbell/cocobob/domain/user/UserRepository.java
+++ b/src/main/java/com/pinkdumbell/cocobob/domain/user/UserRepository.java
@@ -1,10 +1,15 @@
 package com.pinkdumbell.cocobob.domain.user;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByEmail(String email);
+
+    @Query("select distinct u from User u left join fetch u.pets where u.email = :email")
+    Optional<User> findUserByEmailWithPet(@Param("email") String email);
 }

--- a/src/main/java/com/pinkdumbell/cocobob/domain/user/UserService.java
+++ b/src/main/java/com/pinkdumbell/cocobob/domain/user/UserService.java
@@ -192,4 +192,11 @@ public class UserService {
         User user = findUserByToken(accessToken);
         user.updatePassword(bCryptPasswordEncoder.encode(userPasswordRequestDto.getPassword()));
     }
+
+    @Transactional(readOnly = true)
+    public UserGetResponseDto getUserInfo(LoginUserInfo loginUserInfo) {
+        User user = userRepository.findUserByEmailWithPet(loginUserInfo.getEmail())
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        return new UserGetResponseDto(user);
+    }
 }

--- a/src/main/java/com/pinkdumbell/cocobob/domain/user/dto/UserGetResponseDto.java
+++ b/src/main/java/com/pinkdumbell/cocobob/domain/user/dto/UserGetResponseDto.java
@@ -1,0 +1,30 @@
+package com.pinkdumbell.cocobob.domain.user.dto;
+
+import com.pinkdumbell.cocobob.domain.pet.dto.SimplePetInfoDto;
+import com.pinkdumbell.cocobob.domain.user.User;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@AllArgsConstructor
+public class UserGetResponseDto {
+    private final String name;
+    private final String email;
+    private final List<SimplePetInfoDto> pets;
+    private final Long representativeAnimalId;
+
+    public UserGetResponseDto(User entity) {
+        this.name = entity.getUsername();
+        this.email = entity.getEmail();
+        this.pets = entity.getPets().stream().map(SimplePetInfoDto::new).collect(Collectors.toList());
+        if (entity.getRepresentativePet() != null) {
+            this.representativeAnimalId = entity.getRepresentativePet().getId();
+        } else {
+            this.representativeAnimalId = null;
+        }
+
+    }
+}

--- a/src/main/java/com/pinkdumbell/cocobob/domain/user/dto/UserGetResponseDto.java
+++ b/src/main/java/com/pinkdumbell/cocobob/domain/user/dto/UserGetResponseDto.java
@@ -2,6 +2,7 @@ package com.pinkdumbell.cocobob.domain.user.dto;
 
 import com.pinkdumbell.cocobob.domain.pet.dto.SimplePetInfoDto;
 import com.pinkdumbell.cocobob.domain.user.User;
+import io.swagger.annotations.ApiModelProperty;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -11,9 +12,13 @@ import java.util.stream.Collectors;
 @Getter
 @AllArgsConstructor
 public class UserGetResponseDto {
+    @ApiModelProperty(notes = "사용자 이름", example = "은승균")
     private final String name;
+    @ApiModelProperty(notes = "사용자 이메일", example = "test@test.com")
     private final String email;
+    @ApiModelProperty(notes = "반려동물 간단 정보 목록", example = "[ { petId: 1, name: coco, thumbnailPath: https://... }, {...}, ...]")
     private final List<SimplePetInfoDto> pets;
+    @ApiModelProperty(notes = "대표 반려동물 아이디", example = "1")
     private final Long representativeAnimalId;
 
     public UserGetResponseDto(User entity) {

--- a/src/test/java/com/pinkdumbell/cocobob/domain/user/UserControllerUnitTest.java
+++ b/src/test/java/com/pinkdumbell/cocobob/domain/user/UserControllerUnitTest.java
@@ -1,0 +1,71 @@
+package com.pinkdumbell.cocobob.domain.user;
+
+import com.pinkdumbell.cocobob.config.annotation.loginuser.LoginUserArgumentResolver;
+import com.pinkdumbell.cocobob.domain.auth.JwtTokenProvider;
+import com.pinkdumbell.cocobob.domain.pet.dto.SimplePetInfoDto;
+import com.pinkdumbell.cocobob.domain.user.dto.LoginUserInfo;
+import com.pinkdumbell.cocobob.domain.user.dto.UserGetResponseDto;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.core.MethodParameter;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.filter.CharacterEncodingFilter;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import java.util.ArrayList;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.mockito.BDDMockito.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(UserController.class)
+public class UserControllerUnitTest {
+    MockMvc mvc;
+    @Autowired
+    private WebApplicationContext context;
+    @Autowired
+    UserController userController;
+    @MockBean
+    UserService userService;
+    @MockBean
+    JwtTokenProvider jwtTokenProvider;
+    @MockBean
+    LoginUserArgumentResolver loginUserArgumentResolver;
+
+    @BeforeEach
+    void setUp() {
+        mvc = MockMvcBuilders.webAppContextSetup(context)
+                .addFilter(new CharacterEncodingFilter("UTF-8", true))
+                .apply(springSecurity())
+                .build();
+    }
+
+    @Test
+    void testGetUserInfo() throws Exception {
+        String email = "test@test.com";
+        LoginUserInfo loginUserInfo = new LoginUserInfo(email);
+        given(userService.getUserInfo(any(LoginUserInfo.class))).willReturn(new UserGetResponseDto("name", email, new ArrayList<SimplePetInfoDto>(), null));
+        given(loginUserArgumentResolver.resolveArgument(
+                any(MethodParameter.class),
+                any(ModelAndViewContainer.class),
+                any(NativeWebRequest.class),
+                any(WebDataBinderFactory.class)
+        )).willReturn(loginUserInfo);
+
+        mvc.perform(get("/v1/users"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.name").value("name"))
+                .andExpect(jsonPath("$.data.email").value(email))
+                .andExpect(jsonPath("$.data.pets").value(new ArrayList<>()))
+                .andExpect(jsonPath("$.data.representativeAnimalId").doesNotExist());
+    }
+}

--- a/src/test/java/com/pinkdumbell/cocobob/domain/user/UserRepositoryTest.java
+++ b/src/test/java/com/pinkdumbell/cocobob/domain/user/UserRepositoryTest.java
@@ -1,6 +1,10 @@
 package com.pinkdumbell.cocobob.domain.user;
 
 import com.pinkdumbell.cocobob.config.JpaAuditingConfig;
+import com.pinkdumbell.cocobob.domain.pet.Pet;
+import com.pinkdumbell.cocobob.domain.pet.PetRepository;
+import com.pinkdumbell.cocobob.domain.pet.image.PetImage;
+import com.pinkdumbell.cocobob.domain.pet.image.PetImageRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -8,13 +12,22 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 import org.assertj.core.api.Assertions;
 
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
 import java.time.LocalDateTime;
+import java.util.Optional;
 
 @DataJpaTest
 @Import(JpaAuditingConfig.class)
 public class UserRepositoryTest {
     @Autowired
     UserRepository userRepository;
+    @Autowired
+    PetRepository petRepository;
+    @Autowired
+    PetImageRepository petImageRepository;
+    @PersistenceContext
+    EntityManager em;
 
     @Test
     @DisplayName("사용자 생성 시 생성시간 등록 여부를 테스트한다.")
@@ -24,5 +37,46 @@ public class UserRepositoryTest {
 
         Assertions.assertThat(user.getCreatedAt()).isAfter(now);
         Assertions.assertThat(user.getUpdatedAt()).isAfter(now);
+    }
+
+    @Test
+    @DisplayName("사용자 정보를 가져올 때 반려동물 정보를 한 번의 쿼리로 가져오는지 테스트한다.")
+    void testFindUserByEmailWithSimplePetInfo() {
+        String email = "test@test.com";
+        String thumbnailPath = "thumbnailPath";
+        String name = "코코";
+
+        User user = userRepository.save(User.builder()
+                .email(email)
+                .build());
+
+        Pet pet1 = Pet.builder()
+                .user(user)
+                .name(name)
+                .build();
+        pet1.setThumbnailPath(thumbnailPath);
+
+        Pet pet2 = Pet.builder()
+                .user(user)
+                .name("키키")
+                .build();
+        pet2.setThumbnailPath(thumbnailPath);
+
+        PetImage petImage = PetImage.builder()
+                .pet(pet1)
+                .path("imagePath")
+                .build();
+
+        petRepository.save(pet1);
+        petRepository.save(pet2);
+        petImageRepository.save(petImage);
+
+        em.flush();
+        em.clear();
+
+        Optional<User> result = userRepository.findUserByEmailWithPet(email);
+        Assertions.assertThat(result.get().getEmail()).isEqualTo(email);
+        Assertions.assertThat(result.get().getPets().size()).isEqualTo(2);
+        Assertions.assertThat(result.get().getPets().get(0).getName()).isEqualTo(name);
     }
 }

--- a/src/test/java/com/pinkdumbell/cocobob/domain/user/UserServiceUnitTest.java
+++ b/src/test/java/com/pinkdumbell/cocobob/domain/user/UserServiceUnitTest.java
@@ -1,0 +1,38 @@
+package com.pinkdumbell.cocobob.domain.user;
+
+import com.pinkdumbell.cocobob.domain.user.dto.LoginUserInfo;
+import com.pinkdumbell.cocobob.domain.user.dto.UserGetResponseDto;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.mockito.BDDMockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class UserServiceUnitTest {
+    @InjectMocks
+    UserService userService;
+    @Mock
+    UserRepository userRepository;
+
+    @Test
+    void testGetUserInfo() {
+        String email = "test@test.com";
+        given(userRepository.findUserByEmailWithPet(email))
+                .willReturn(Optional.ofNullable(User.builder()
+                        .username("name")
+                        .email(email)
+                        .build()));
+
+        UserGetResponseDto result = userService.getUserInfo(new LoginUserInfo(email));
+        Assertions.assertThat(result.getEmail()).isEqualTo(email);
+        Assertions.assertThat(result.getName()).isEqualTo("name");
+        Assertions.assertThat(result.getPets().size()).isEqualTo(0);
+        Assertions.assertThat(result.getRepresentativeAnimalId()).isNull();
+    }
+}


### PR DESCRIPTION
[CB-257]

🔨 Jira 태스크
[CB-257] [BE] 사용자 정보를 가져오는 기능이 필요함


📐 구현한 내용
- GetUserInfo API 작성
- API 작성에 따른 유닛테스트 작성
- 스웨거를 통한 API 명세 작성
- 불필요한 쿼리 제거를 위한 연관관계, 지연로딩 수정


🚧 논의 사항




[CB-257]: https://cocobob.atlassian.net/browse/CB-257?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CB-257]: https://cocobob.atlassian.net/browse/CB-257?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ