### PR TITLE
Cb 285 be query dsl이 적용되지 않음

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,13 @@
+
+buildscript {
+	ext {
+		queryDslVersion = "5.0.0"
+	}}
+
 plugins {
 	id 'org.springframework.boot' version '2.7.1'
 	id 'io.spring.dependency-management' version '1.0.11.RELEASE'
+	id "com.ewerk.gradle.plugins.querydsl" version "1.0.10" //QueryDSL Plugins
 	id 'java'
 }
 
@@ -44,6 +51,11 @@ dependencies {
 	//email
 	implementation 'org.springframework.boot:spring-boot-starter-mail'
 
+	//Query DSL
+	implementation "com.querydsl:querydsl-jpa:${queryDslVersion}"
+	implementation "com.querydsl:querydsl-apt:${queryDslVersion}"
+
+
 	implementation 'org.springframework:spring-test:5.3.21'
 
 	implementation 'junit:junit:4.13.1'
@@ -60,3 +72,29 @@ dependencies {
 tasks.named('test') {
 	useJUnitPlatform()
 }
+
+// querydsl에서 사용할 경로 설정
+
+def querydslDir = "$buildDir/generated/querydsl"
+
+// JPA 사용 여부와 사용할 경로를 설정
+querydsl {
+	jpa = true
+	querydslSourcesDir = querydslDir
+}
+// build 시 사용할 sourceSet 추가
+sourceSets {
+	main.java.srcDir querydslDir
+}
+// querydsl 컴파일시 사용할 옵션 설정
+compileQuerydsl{
+	options.annotationProcessorPath = configurations.querydsl
+}
+// querydsl 이 compileClassPath 를 상속하도록 설정
+configurations {
+	compileOnly {
+		extendsFrom annotationProcessor
+	}
+	querydsl.extendsFrom compileClasspath
+}
+

--- a/src/main/java/com/pinkdumbell/cocobob/config/QueryDslConfig.java
+++ b/src/main/java/com/pinkdumbell/cocobob/config/QueryDslConfig.java
@@ -1,0 +1,20 @@
+package com.pinkdumbell.cocobob.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QueryDslConfig {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+
+}

--- a/src/main/java/com/pinkdumbell/cocobob/domain/product/ProductController.java
+++ b/src/main/java/com/pinkdumbell/cocobob/domain/product/ProductController.java
@@ -60,11 +60,12 @@ public class ProductController {
 
     })
     @GetMapping("/{productId}")
-    public ResponseEntity<ProductDetailResponseClass> productDetail(@PathVariable Long productId) {
+    public ResponseEntity<ProductDetailResponseClass> productDetail(@PathVariable Long productId,
+        @LoginUser LoginUserInfo loginUserInfo) {
 
         return ResponseEntity.ok(
             new ProductDetailResponseClass(HttpStatus.OK.value(), "SUCCESS LOAD PROUDCT",
-                "상품 가져오기 성공", productService.findProductDetailById(productId)));
+                "상품 가져오기 성공", productService.findProductDetailById(productId,loginUserInfo.getEmail())));
     }
 
     @ApiOperation(value = "productSpecificSearchDto", notes = "상품 정보 조회")
@@ -85,6 +86,7 @@ public class ProductController {
                 "상품 검색 성공",
                 productService.elasticSearchProducts(productSpecificSearchDto, pageable)));
     }
+
     @ApiOperation(value = "searchAllProductsWithLikes", notes = "상품 정보 조회(좋아요 갯수와 사용자가 좋아하는 것도 표시)")
     @ApiImplicitParams({
         @ApiImplicitParam(name = "page", dataType = "integer", paramType = "query",

--- a/src/main/java/com/pinkdumbell/cocobob/domain/product/ProductController.java
+++ b/src/main/java/com/pinkdumbell/cocobob/domain/product/ProductController.java
@@ -1,9 +1,11 @@
 package com.pinkdumbell.cocobob.domain.product;
 
 import com.pinkdumbell.cocobob.common.dto.CommonResponseDto;
+import com.pinkdumbell.cocobob.config.annotation.loginuser.LoginUser;
 import com.pinkdumbell.cocobob.domain.product.dto.FindAllResponseDto;
 import com.pinkdumbell.cocobob.domain.product.dto.ProductDetailResponseDto;
 import com.pinkdumbell.cocobob.domain.product.dto.ProductSpecificSearchDto;
+import com.pinkdumbell.cocobob.domain.user.dto.LoginUserInfo;
 import com.pinkdumbell.cocobob.exception.ErrorResponse;
 import io.swagger.annotations.ApiImplicitParam;
 import io.swagger.annotations.ApiImplicitParams;
@@ -83,4 +85,23 @@ public class ProductController {
                 "상품 검색 성공",
                 productService.elasticSearchProducts(productSpecificSearchDto, pageable)));
     }
+    @ApiOperation(value = "searchAllProductsWithLikes", notes = "상품 정보 조회(좋아요 갯수와 사용자가 좋아하는 것도 표시)")
+    @ApiImplicitParams({
+        @ApiImplicitParam(name = "page", dataType = "integer", paramType = "query",
+            value = "페이지 번호(0...N)"),
+        @ApiImplicitParam(name = "size", dataType = "integer", paramType = "query",
+            value = "페이지 크기")
+    })
+    @GetMapping("/search/likes")
+    public ResponseEntity<ProvideAllResponseClass> searchAllProductsWithLikes(
+        ProductSpecificSearchDto productSpecificSearchDto, @LoginUser LoginUserInfo loginUserInfo,
+        Pageable pageable) {
+
+        return ResponseEntity.ok(
+            new ProvideAllResponseClass(HttpStatus.OK.value(), "SUCCESS LOAD PRODUCT",
+                "상품 검색 성공",
+                productService.queryDslSearchProducts(productSpecificSearchDto,
+                    loginUserInfo.getEmail(), pageable)));
+    }
+
 }

--- a/src/main/java/com/pinkdumbell/cocobob/domain/product/ProductController.java
+++ b/src/main/java/com/pinkdumbell/cocobob/domain/product/ProductController.java
@@ -69,6 +69,12 @@ public class ProductController {
     }
 
     @ApiOperation(value = "productSpecificSearchDto", notes = "상품 정보 조회")
+    @ApiResponses(value = {
+        @ApiResponse(code = 200, message = "", response = ProvideAllResponseClass.class),
+        @ApiResponse(code = 400, message = "", response = ErrorResponse.class),
+        @ApiResponse(code = 500, message = "INTERNAL SERVER ERROR", response = ErrorResponse.class)
+
+    })
     @ApiImplicitParams({
         @ApiImplicitParam(name = "page", dataType = "integer", paramType = "query",
             value = "페이지 번호(0...N)"),
@@ -88,6 +94,12 @@ public class ProductController {
     }
 
     @ApiOperation(value = "searchAllProductsWithLikes", notes = "상품 정보 조회(좋아요 갯수와 사용자가 좋아하는 것도 표시)")
+    @ApiResponses(value = {
+        @ApiResponse(code = 200, message = "", response = ProvideAllResponseClass.class),
+        @ApiResponse(code = 400, message = "", response = ErrorResponse.class),
+        @ApiResponse(code = 500, message = "INTERNAL SERVER ERROR", response = ErrorResponse.class)
+
+    })
     @ApiImplicitParams({
         @ApiImplicitParam(name = "page", dataType = "integer", paramType = "query",
             value = "페이지 번호(0...N)"),

--- a/src/main/java/com/pinkdumbell/cocobob/domain/product/ProductController.java
+++ b/src/main/java/com/pinkdumbell/cocobob/domain/product/ProductController.java
@@ -90,7 +90,9 @@ public class ProductController {
         @ApiImplicitParam(name = "page", dataType = "integer", paramType = "query",
             value = "페이지 번호(0...N)"),
         @ApiImplicitParam(name = "size", dataType = "integer", paramType = "query",
-            value = "페이지 크기")
+            value = "페이지 크기"),
+        @ApiImplicitParam(name = "sortCriteria", dataType = "string", paramType = "query",
+            value = "정렬(사용법: 컬럼명,ASC|DESC)")
     })
     @GetMapping("/search/likes")
     public ResponseEntity<ProvideAllResponseClass> searchAllProductsWithLikes(

--- a/src/main/java/com/pinkdumbell/cocobob/domain/product/ProductPedicate.java
+++ b/src/main/java/com/pinkdumbell/cocobob/domain/product/ProductPedicate.java
@@ -1,0 +1,118 @@
+package com.pinkdumbell.cocobob.domain.product;
+
+import com.pinkdumbell.cocobob.domain.product.dto.ProductSpecificSearchDto;
+
+import com.querydsl.core.BooleanBuilder;
+
+public class ProductPedicate {
+
+    public static BooleanBuilder makeProductBooleanBuilder(
+        ProductSpecificSearchDto requestParameter) {
+        QProduct qProduct = QProduct.product;
+        BooleanBuilder builder = new BooleanBuilder();
+
+        if (requestParameter.getCode() != null) {
+            builder.and(qProduct.code.eq(requestParameter.getCode()));
+        }
+
+        if (requestParameter.getName() != null) {
+            builder.and(qProduct.name.contains(requestParameter.getName())); // 상품명
+        }
+
+        if (requestParameter.getDescription() != null) {
+            builder.and(qProduct.description.contains(requestParameter.getDescription())); // 상품 내용
+        }
+
+        if (requestParameter.getBeef() != null) {
+            builder.and(qProduct.beef.eq(requestParameter.getBeef())); // 소고기 포함 유무
+        }
+
+        if (requestParameter.getMutton() != null) {
+            builder.and(qProduct.mutton.eq(requestParameter.getMutton())); // 양고기 포함 유무
+        }
+
+        if (requestParameter.getChicken() != null) {
+            builder.and(qProduct.chicken.eq(requestParameter.getChicken())); // 닭고기 포함 유무
+        }
+
+        if (requestParameter.getDuck() != null) {
+            builder.and(qProduct.duck.eq(requestParameter.getDuck())); // 오리고기 포함 유무
+        }
+
+        if (requestParameter.getTurkey() != null) {
+            builder.and(qProduct.turkey.eq(requestParameter.getTurkey())); // 칠면조 포함 유무
+        }
+
+        if (requestParameter.getMeat() != null) {
+            builder.and(qProduct.meat.eq(requestParameter.getMeat())); //  돼지고기 포함 유무
+        }
+
+        if (requestParameter.getSalmon() != null) {
+            builder.and(qProduct.salmon.eq(requestParameter.getSalmon())); // 연어 포함 유무
+        }
+
+        if (requestParameter.getHydrolyticBeef() != null) {
+            builder.and(
+                qProduct.hydrolyticBeef.eq(requestParameter.getHydrolyticBeef())); // 가수분해 소고기 포함 유무
+        }
+
+        if (requestParameter.getHydrolyticMutton() != null) {
+            builder.and(
+                qProduct.hydrolyticMutton.eq(
+                    requestParameter.getHydrolyticMutton())); // 가수분해 양고기 포함 유무
+        }
+
+        if (requestParameter.getHydrolyticChicken() != null) {
+            builder.and(
+                qProduct.hydrolyticChicken.eq(
+                    requestParameter.getHydrolyticChicken())); // 가수분해 닭고기 포함 유무
+        }
+
+        if (requestParameter.getHydrolyticDuck() != null) {
+            builder.and(
+                qProduct.hydrolyticDuck.eq(
+                    requestParameter.getHydrolyticDuck())); // 가수분해 오리고기 포함 유무
+        }
+
+        if (requestParameter.getHydrolyticTurkey() != null) {
+            builder.and(
+                qProduct.hydrolyticTurkey.eq(
+                    requestParameter.getHydrolyticTurkey())); // 가수분해 칠면조 포함 유무
+        }
+
+        if (requestParameter.getHydrolyticMeat() != null) {
+            builder.and(
+                qProduct.hydrolyticMeat.eq(
+                    requestParameter.getHydrolyticMeat())); // 가수분해 돼지고기 포함 유무
+        }
+
+        if (requestParameter.getHydrolyticSalmon() != null) {
+            builder.and(
+                qProduct.hydrolyticSalmon.eq(
+                    requestParameter.getHydrolyticSalmon())); // 가수분해 연어 포함 유무
+        }
+
+        if (requestParameter.getAafco() != null) {
+            builder.and(qProduct.isAAFCOSatisfied.eq(requestParameter.getAafco()));
+        }
+
+        if (requestParameter.getAged() != null) {
+            builder.and(qProduct.aged.eq(requestParameter.getAged()));
+        }
+
+        if (requestParameter.getPregnant() != null) {
+            builder.and(qProduct.pregnant.eq(requestParameter.getPregnant()));
+        }
+
+        if (requestParameter.getGrowing() != null) {
+            builder.and(qProduct.growing.eq(requestParameter.getGrowing()));
+        }
+
+        if (requestParameter.getObesity() != null) {
+            builder.and(qProduct.obesity.eq(requestParameter.getObesity()));
+        }
+
+        return builder;
+    }
+
+}

--- a/src/main/java/com/pinkdumbell/cocobob/domain/product/ProductPredicate.java
+++ b/src/main/java/com/pinkdumbell/cocobob/domain/product/ProductPredicate.java
@@ -4,7 +4,7 @@ import com.pinkdumbell.cocobob.domain.product.dto.ProductSpecificSearchDto;
 
 import com.querydsl.core.BooleanBuilder;
 
-public class ProductPedicate {
+public class ProductPredicate {
 
     public static BooleanBuilder makeProductBooleanBuilder(
         ProductSpecificSearchDto requestParameter) {

--- a/src/main/java/com/pinkdumbell/cocobob/domain/product/ProductRepository.java
+++ b/src/main/java/com/pinkdumbell/cocobob/domain/product/ProductRepository.java
@@ -7,7 +7,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
 public interface ProductRepository extends JpaRepository<Product, Long>,
-    JpaSpecificationExecutor<Product> {
+    JpaSpecificationExecutor<Product>,ProductSearchQueryDsl {
 
     @Override
     Optional<Product> findById(Long productId);

--- a/src/main/java/com/pinkdumbell/cocobob/domain/product/ProductSearchQueryDsl.java
+++ b/src/main/java/com/pinkdumbell/cocobob/domain/product/ProductSearchQueryDsl.java
@@ -1,0 +1,14 @@
+package com.pinkdumbell.cocobob.domain.product;
+
+import com.pinkdumbell.cocobob.domain.product.dto.ProductSimpleResponseDto;
+import com.pinkdumbell.cocobob.domain.product.dto.ProductSpecificSearchDto;
+import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+public interface ProductSearchQueryDsl {
+
+    PageImpl<ProductSimpleResponseDto> findAllWithLikes(ProductSpecificSearchDto productSpecificSearchDto, Long userId,
+        Pageable pageable);
+}

--- a/src/main/java/com/pinkdumbell/cocobob/domain/product/ProductSearchQueryDslImpl.java
+++ b/src/main/java/com/pinkdumbell/cocobob/domain/product/ProductSearchQueryDslImpl.java
@@ -51,7 +51,7 @@ public class ProductSearchQueryDslImpl implements ProductSearchQueryDsl {
                         "isUserLike")))
             .from(qProduct)
             .leftJoin(qLike).on(qProduct.id.eq(qLike.product.id))
-            .where(ProductPedicate.makeProductBooleanBuilder(productSpecificSearchDto));
+            .where(ProductPredicate.makeProductBooleanBuilder(productSpecificSearchDto));
 
         if (productSpecificSearchDto.getSortCriteria() != null) {
             String sortCriteria = productSpecificSearchDto.getSortCriteria();

--- a/src/main/java/com/pinkdumbell/cocobob/domain/product/ProductSearchQueryDslImpl.java
+++ b/src/main/java/com/pinkdumbell/cocobob/domain/product/ProductSearchQueryDslImpl.java
@@ -31,14 +31,17 @@ public class ProductSearchQueryDslImpl implements ProductSearchQueryDsl {
 
         List<ProductSimpleResponseDto> result = jpaQueryFactory.select(
                 Projections.constructor(ProductSimpleResponseDto.class,
-                    qProduct.id, qProduct.code, qProduct.name, qProduct.category, qProduct.price,
-                    qProduct.thumbnail, qProduct.description, qProduct.isAAFCOSatisfied, qProduct.aged,
-                    qProduct.pregnant,
-                    ExpressionUtils.as(JPAExpressions.select(qLike.likeId.count())
+                    qProduct.id.as("productId"), qProduct.code.as("code"), qProduct.name.as("name"),
+                    qProduct.category.as("category"), qProduct.price.as("price"),
+                    qProduct.thumbnail.as("thumbnail"), qProduct.description.as("description"),
+                    qProduct.isAAFCOSatisfied.as("isAAFCOSatisfied"), qProduct.aged.as("aged"),
+                    qProduct.growing.as("growing"), qProduct.pregnant.as("pregnant"),
+                    qProduct.obesity.as("obesity"),
+                    ExpressionUtils.as(JPAExpressions.select(qLike.count())
                         .from(qLike)
                         .where(qLike.product.eq(qProduct)), "likes"),
                     ExpressionUtils.as(
-                        JPAExpressions.select(qLike.likeId.isNotNull())
+                        JPAExpressions.select(qLike.isNotNull())
                             .from(qLike)
                             .where(qLike.user.id.eq(userId)), "isUserLike")))
             .from(qProduct)
@@ -48,6 +51,6 @@ public class ProductSearchQueryDslImpl implements ProductSearchQueryDsl {
             .limit(pageable.getPageSize())
             .fetch();
 
-        return new PageImpl <>(result,pageable,result.size());
+        return new PageImpl<>(result, pageable, result.size());
     }
 }

--- a/src/main/java/com/pinkdumbell/cocobob/domain/product/ProductSearchQueryDslImpl.java
+++ b/src/main/java/com/pinkdumbell/cocobob/domain/product/ProductSearchQueryDslImpl.java
@@ -43,7 +43,7 @@ public class ProductSearchQueryDslImpl implements ProductSearchQueryDsl {
                     ExpressionUtils.as(
                         JPAExpressions.select(qLike.isNotNull())
                             .from(qLike)
-                            .where(qLike.user.id.eq(userId)), "isUserLike")))
+                            .where(qLike.user.id.eq(userId),qLike.product.id.eq(qProduct.id)), "isUserLike")))
             .from(qProduct)
             .leftJoin(qLike).on(qProduct.id.eq(qLike.product.id))
             .where(ProductPedicate.makeProductBooleanBuilder(productSpecificSearchDto))

--- a/src/main/java/com/pinkdumbell/cocobob/domain/product/ProductSearchQueryDslImpl.java
+++ b/src/main/java/com/pinkdumbell/cocobob/domain/product/ProductSearchQueryDslImpl.java
@@ -1,0 +1,53 @@
+package com.pinkdumbell.cocobob.domain.product;
+
+
+import com.pinkdumbell.cocobob.domain.product.dto.ProductSimpleResponseDto;
+import com.pinkdumbell.cocobob.domain.product.dto.ProductSpecificSearchDto;
+import com.pinkdumbell.cocobob.domain.product.like.QLike;
+import com.querydsl.core.types.ExpressionUtils;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class ProductSearchQueryDslImpl implements ProductSearchQueryDsl {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public PageImpl<ProductSimpleResponseDto> findAllWithLikes(
+        ProductSpecificSearchDto productSpecificSearchDto,
+        Long userId,
+        Pageable pageable) {
+        QProduct qProduct = QProduct.product;
+        QLike qLike = QLike.like;
+
+        List<ProductSimpleResponseDto> result = jpaQueryFactory.select(
+                Projections.constructor(ProductSimpleResponseDto.class,
+                    qProduct.id, qProduct.code, qProduct.name, qProduct.category, qProduct.price,
+                    qProduct.thumbnail, qProduct.description, qProduct.isAAFCOSatisfied, qProduct.aged,
+                    qProduct.pregnant,
+                    ExpressionUtils.as(JPAExpressions.select(qLike.likeId.count())
+                        .from(qLike)
+                        .where(qLike.product.eq(qProduct)), "likes"),
+                    ExpressionUtils.as(
+                        JPAExpressions.select(qLike.likeId.isNotNull())
+                            .from(qLike)
+                            .where(qLike.user.id.eq(userId)), "isUserLike")))
+            .from(qProduct)
+            .leftJoin(qLike).on(qProduct.id.eq(qLike.product.id))
+            .where(ProductPedicate.makeProductBooleanBuilder(productSpecificSearchDto))
+            .offset(pageable.getOffset())
+            .limit(pageable.getPageSize())
+            .fetch();
+
+        return new PageImpl <>(result,pageable,result.size());
+    }
+}

--- a/src/main/java/com/pinkdumbell/cocobob/domain/product/ProductService.java
+++ b/src/main/java/com/pinkdumbell/cocobob/domain/product/ProductService.java
@@ -4,6 +4,7 @@ import com.pinkdumbell.cocobob.domain.product.dto.FindAllResponseDto;
 import com.pinkdumbell.cocobob.domain.product.dto.ProductDetailResponseDto;
 
 import com.pinkdumbell.cocobob.domain.product.dto.ProductSpecificSearchDto;
+import com.pinkdumbell.cocobob.domain.user.UserRepository;
 import com.pinkdumbell.cocobob.exception.CustomException;
 import com.pinkdumbell.cocobob.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
@@ -18,6 +19,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class ProductService {
 
     private final ProductRepository productRepository;
+    private final UserRepository userRepository;
 
     public ProductDetailResponseDto findProductDetailById(Long productId) {
 
@@ -34,6 +36,13 @@ public class ProductService {
 
         return new FindAllResponseDto(productRepository.findAll(
             ProductSearchSpecification.makeProductSpecification(requestParameter), pageable));
+
+    }
+
+    public FindAllResponseDto queryDslSearchProducts(ProductSpecificSearchDto requestParameter,String email,
+        Pageable pageable) {
+        Long userId = userRepository.findByEmail(email).get().getId();
+        return new FindAllResponseDto(productRepository.findAllWithLikes(requestParameter,userId,pageable));
 
     }
 }

--- a/src/main/java/com/pinkdumbell/cocobob/domain/product/ProductService.java
+++ b/src/main/java/com/pinkdumbell/cocobob/domain/product/ProductService.java
@@ -41,7 +41,7 @@ public class ProductService {
 
         return new ProductDetailResponseDto(foundProduct,
             likeRepository.countByProduct(foundProduct),
-            likeRepository.findByProduct(foundProduct).isPresent());
+            likeRepository.findByProductAndUser(foundProduct, foundUser).isPresent());
     }
 
     public FindAllResponseDto elasticSearchProducts(ProductSpecificSearchDto requestParameter,
@@ -55,9 +55,13 @@ public class ProductService {
     public FindAllResponseDto queryDslSearchProducts(ProductSpecificSearchDto requestParameter,
         String email,
         Pageable pageable) {
-        Long userId = userRepository.findByEmail(email).get().getId();
+
+        User user = userRepository.findByEmail(email).orElseThrow(() -> {
+            throw new CustomException(ErrorCode.USER_NOT_FOUND);
+        });
+
         return new FindAllResponseDto(
-            productRepository.findAllWithLikes(requestParameter, userId, pageable));
+            productRepository.findAllWithLikes(requestParameter, user.getId(), pageable));
 
     }
 }

--- a/src/main/java/com/pinkdumbell/cocobob/domain/product/ProductService.java
+++ b/src/main/java/com/pinkdumbell/cocobob/domain/product/ProductService.java
@@ -4,9 +4,14 @@ import com.pinkdumbell.cocobob.domain.product.dto.FindAllResponseDto;
 import com.pinkdumbell.cocobob.domain.product.dto.ProductDetailResponseDto;
 
 import com.pinkdumbell.cocobob.domain.product.dto.ProductSpecificSearchDto;
+import com.pinkdumbell.cocobob.domain.product.like.Like;
+import com.pinkdumbell.cocobob.domain.product.like.LikeId;
+import com.pinkdumbell.cocobob.domain.product.like.LikeRepository;
+import com.pinkdumbell.cocobob.domain.user.User;
 import com.pinkdumbell.cocobob.domain.user.UserRepository;
 import com.pinkdumbell.cocobob.exception.CustomException;
 import com.pinkdumbell.cocobob.exception.ErrorCode;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.data.domain.Pageable;
@@ -21,14 +26,22 @@ public class ProductService {
     private final ProductRepository productRepository;
     private final UserRepository userRepository;
 
-    public ProductDetailResponseDto findProductDetailById(Long productId) {
+    private final LikeRepository likeRepository;
+
+    public ProductDetailResponseDto findProductDetailById(Long productId, String userEmail) {
 
         Product foundProduct = productRepository.findById(productId).orElseThrow(
             () -> {
                 throw new CustomException(ErrorCode.PRODUCT_NOT_FOUND);
             });
 
-        return new ProductDetailResponseDto(foundProduct);
+        User foundUser = userRepository.findByEmail(userEmail).orElseThrow(() -> {
+            throw new CustomException(ErrorCode.USER_NOT_FOUND);
+        });
+
+        return new ProductDetailResponseDto(foundProduct,
+            likeRepository.countByProduct(foundProduct),
+            likeRepository.findByProduct(foundProduct).isPresent());
     }
 
     public FindAllResponseDto elasticSearchProducts(ProductSpecificSearchDto requestParameter,
@@ -39,10 +52,12 @@ public class ProductService {
 
     }
 
-    public FindAllResponseDto queryDslSearchProducts(ProductSpecificSearchDto requestParameter,String email,
+    public FindAllResponseDto queryDslSearchProducts(ProductSpecificSearchDto requestParameter,
+        String email,
         Pageable pageable) {
         Long userId = userRepository.findByEmail(email).get().getId();
-        return new FindAllResponseDto(productRepository.findAllWithLikes(requestParameter,userId,pageable));
+        return new FindAllResponseDto(
+            productRepository.findAllWithLikes(requestParameter, userId, pageable));
 
     }
 }

--- a/src/main/java/com/pinkdumbell/cocobob/domain/product/dto/FindAllResponseDto.java
+++ b/src/main/java/com/pinkdumbell/cocobob/domain/product/dto/FindAllResponseDto.java
@@ -10,6 +10,7 @@ import java.util.stream.Collectors;
 import lombok.Getter;
 
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 
 
 @Getter
@@ -42,5 +43,17 @@ public class FindAllResponseDto {
         this.isFirst = pages.isFirst();
         this.isLast = pages.isLast();
         this.isEmpty = pages.isEmpty();
+    }
+
+    public FindAllResponseDto(PageImpl<ProductSimpleResponseDto> pages) {
+        this.productList = pages.getContent();
+        this.totalPages = pages.getTotalPages();
+        this.totalElements = pages.getTotalElements();
+        this.pageSize = pages.getSize();
+        this.pageNumber = pages.getNumber();
+        this.isFirst = pages.isFirst();
+        this.isLast = pages.isLast();
+        this.isEmpty = pages.isEmpty();
+
     }
 }

--- a/src/main/java/com/pinkdumbell/cocobob/domain/product/dto/ProductDetailResponseDto.java
+++ b/src/main/java/com/pinkdumbell/cocobob/domain/product/dto/ProductDetailResponseDto.java
@@ -1,6 +1,7 @@
 package com.pinkdumbell.cocobob.domain.product.dto;
 
 import com.pinkdumbell.cocobob.domain.product.Product;
+import com.pinkdumbell.cocobob.domain.product.like.Like;
 import io.swagger.annotations.ApiModelProperty;
 import java.util.List;
 import lombok.AllArgsConstructor;
@@ -97,8 +98,12 @@ public class ProductDetailResponseDto {
     @ApiModelProperty(notes = "비만견 기준 충족", example = "false")
     private Boolean obesity;
     // 추후 추가예정
-    // private int likeCount;
-    public ProductDetailResponseDto(Product product) {
+    @ApiModelProperty(notes = "상품 좋아요 수", example = "100")
+    private Long likes;
+    @ApiModelProperty(notes = "유저가 좋아한 상품인지", example = "false")
+    private boolean isUserLike;
+
+    public ProductDetailResponseDto(Product product, Long likes, boolean isUserLike) {
 
         this.productId = product.getId();
         this.code = product.getCode();
@@ -137,8 +142,8 @@ public class ProductDetailResponseDto {
         this.hydrolyticTurkey = product.getHydrolyticTurkey();
         this.hydrolyticMeat = product.getHydrolyticMeat();
         this.hydrolyticSalmon = product.getHydrolyticSalmon();
-        //추후 추가 예정
-        //this.likeCount;
+        this.likes =likes;
+        this.isUserLike = isUserLike;
         this.aged = product.getAged();
         this.growing = product.getGrowing();
         this.pregnant = product.getPregnant();

--- a/src/main/java/com/pinkdumbell/cocobob/domain/product/dto/ProductDetailResponseDto.java
+++ b/src/main/java/com/pinkdumbell/cocobob/domain/product/dto/ProductDetailResponseDto.java
@@ -101,7 +101,7 @@ public class ProductDetailResponseDto {
     @ApiModelProperty(notes = "상품 좋아요 수", example = "100")
     private Long likes;
     @ApiModelProperty(notes = "유저가 좋아한 상품인지", example = "false")
-    private boolean isUserLike;
+    private Boolean isUserLike;
 
     public ProductDetailResponseDto(Product product, Long likes, boolean isUserLike) {
 
@@ -142,7 +142,7 @@ public class ProductDetailResponseDto {
         this.hydrolyticTurkey = product.getHydrolyticTurkey();
         this.hydrolyticMeat = product.getHydrolyticMeat();
         this.hydrolyticSalmon = product.getHydrolyticSalmon();
-        this.likes =likes;
+        this.likes = likes;
         this.isUserLike = isUserLike;
         this.aged = product.getAged();
         this.growing = product.getGrowing();

--- a/src/main/java/com/pinkdumbell/cocobob/domain/product/dto/ProductSimpleResponseDto.java
+++ b/src/main/java/com/pinkdumbell/cocobob/domain/product/dto/ProductSimpleResponseDto.java
@@ -37,6 +37,10 @@ public class ProductSimpleResponseDto {
     private boolean pregnant;
     @ApiModelProperty(notes = "비만견 기준 만족", example = "true")
     private boolean obesity;
+    @ApiModelProperty(notes = "좋아요 수", example = "12312")
+    private int likes;
+    @ApiModelProperty(notes = "사용자가 좋아요 누른 게시물", example = "false")
+    private int isUserLike;
 
     public ProductSimpleResponseDto(Product product) {
         this.productId = product.getId();

--- a/src/main/java/com/pinkdumbell/cocobob/domain/product/dto/ProductSimpleResponseDto.java
+++ b/src/main/java/com/pinkdumbell/cocobob/domain/product/dto/ProductSimpleResponseDto.java
@@ -38,9 +38,9 @@ public class ProductSimpleResponseDto {
     @ApiModelProperty(notes = "비만견 기준 만족", example = "true")
     private boolean obesity;
     @ApiModelProperty(notes = "좋아요 수", example = "12312")
-    private int likes;
+    private Long likes;
     @ApiModelProperty(notes = "사용자가 좋아요 누른 게시물", example = "false")
-    private int isUserLike;
+    private boolean isUserLike;
 
     public ProductSimpleResponseDto(Product product) {
         this.productId = product.getId();
@@ -56,5 +56,6 @@ public class ProductSimpleResponseDto {
         this.pregnant = product.getPregnant();
         this.obesity = product.getObesity();
     }
+
 
 }

--- a/src/main/java/com/pinkdumbell/cocobob/domain/product/dto/ProductSpecificSearchDto.java
+++ b/src/main/java/com/pinkdumbell/cocobob/domain/product/dto/ProductSpecificSearchDto.java
@@ -54,4 +54,7 @@ public class ProductSpecificSearchDto {
     private Boolean pregnant;
     @ApiModelProperty(notes = "비만견 기준 충족", example = "false")
     private Boolean obesity;
+    @ApiModelProperty(notes = "정렬 기준", example = "PRICE,ASC | LIKE,DESC ")
+    private String sortCriteria;
+
 }

--- a/src/main/java/com/pinkdumbell/cocobob/domain/product/like/Like.java
+++ b/src/main/java/com/pinkdumbell/cocobob/domain/product/like/Like.java
@@ -2,6 +2,8 @@ package com.pinkdumbell.cocobob.domain.product.like;
 
 import com.pinkdumbell.cocobob.domain.product.Product;
 import com.pinkdumbell.cocobob.domain.user.User;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -10,6 +12,8 @@ import javax.persistence.*;
 @Table(name = "\"like\"")
 @Getter
 @NoArgsConstructor
+@AllArgsConstructor
+@Builder
 @Entity
 public class Like {
     @EmbeddedId

--- a/src/main/java/com/pinkdumbell/cocobob/domain/product/like/LikeController.java
+++ b/src/main/java/com/pinkdumbell/cocobob/domain/product/like/LikeController.java
@@ -25,10 +25,12 @@ public class LikeController {
     @PostMapping("")
     public ResponseEntity<CommonResponseDto> like(@RequestBody LikeRequestDto likeRequestDto) {
 
+        likeService.like(likeRequestDto);
+
         return ResponseEntity.ok(CommonResponseDto.builder()
             .status(HttpStatus.OK.value()).
-            code("Update Password Success").
-            message("비밀번호가 성공적으로 변경되었습니다.").
+            code("Like Product Success").
+            message("좋아요 성공").
             data(null).
             build());
     }
@@ -36,10 +38,12 @@ public class LikeController {
     @DeleteMapping("")
     public ResponseEntity<CommonResponseDto> unLike(@RequestBody LikeRequestDto likeRequestDto) {
 
+        likeService.unLike(likeRequestDto);
+
         return ResponseEntity.ok(CommonResponseDto.builder()
             .status(HttpStatus.OK.value()).
-            code("Update Password Success").
-            message("비밀번호가 성공적으로 변경되었습니다.").
+            code("Unlike Product Success").
+            message("좋아요 해제 성공").
             data(null).
             build());
     }

--- a/src/main/java/com/pinkdumbell/cocobob/domain/product/like/LikeController.java
+++ b/src/main/java/com/pinkdumbell/cocobob/domain/product/like/LikeController.java
@@ -1,0 +1,47 @@
+package com.pinkdumbell.cocobob.domain.product.like;
+
+import com.pinkdumbell.cocobob.common.dto.CommonResponseDto;
+import com.pinkdumbell.cocobob.domain.product.dto.FindAllResponseDto;
+import com.pinkdumbell.cocobob.domain.product.like.dto.LikeRequestDto;
+import io.swagger.annotations.ApiOperation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@ApiOperation("Product API")
+@RequestMapping("/v1/likes")
+@RequiredArgsConstructor
+@RestController
+public class LikeController {
+
+    private final LikeService likeService;
+
+
+    @PostMapping("")
+    public ResponseEntity<CommonResponseDto> like(@RequestBody LikeRequestDto likeRequestDto) {
+
+        return ResponseEntity.ok(CommonResponseDto.builder()
+            .status(HttpStatus.OK.value()).
+            code("Update Password Success").
+            message("비밀번호가 성공적으로 변경되었습니다.").
+            data(null).
+            build());
+    }
+
+    @DeleteMapping("")
+    public ResponseEntity<CommonResponseDto> unLike(@RequestBody LikeRequestDto likeRequestDto) {
+
+        return ResponseEntity.ok(CommonResponseDto.builder()
+            .status(HttpStatus.OK.value()).
+            code("Update Password Success").
+            message("비밀번호가 성공적으로 변경되었습니다.").
+            data(null).
+            build());
+    }
+
+}

--- a/src/main/java/com/pinkdumbell/cocobob/domain/product/like/LikeId.java
+++ b/src/main/java/com/pinkdumbell/cocobob/domain/product/like/LikeId.java
@@ -1,5 +1,6 @@
 package com.pinkdumbell.cocobob.domain.product.like;
 
+import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -10,6 +11,7 @@ import java.io.Serializable;
 
 @Getter
 @NoArgsConstructor
+@AllArgsConstructor
 @EqualsAndHashCode
 @Embeddable
 public class LikeId implements Serializable {

--- a/src/main/java/com/pinkdumbell/cocobob/domain/product/like/LikeRepository.java
+++ b/src/main/java/com/pinkdumbell/cocobob/domain/product/like/LikeRepository.java
@@ -1,6 +1,7 @@
 package com.pinkdumbell.cocobob.domain.product.like;
 
 import com.pinkdumbell.cocobob.domain.product.Product;
+import com.pinkdumbell.cocobob.domain.user.User;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -10,4 +11,6 @@ public interface LikeRepository extends JpaRepository<Like,LikeId> {
     Long countByProduct(Product product);
 
     Optional<Like> findByProduct(Product product);
+
+    Optional<Like> findByProductAndUser(Product product,User user);
 }

--- a/src/main/java/com/pinkdumbell/cocobob/domain/product/like/LikeRepository.java
+++ b/src/main/java/com/pinkdumbell/cocobob/domain/product/like/LikeRepository.java
@@ -1,9 +1,13 @@
 package com.pinkdumbell.cocobob.domain.product.like;
 
+import com.pinkdumbell.cocobob.domain.product.Product;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface LikeRepository extends JpaRepository<Like,LikeId> {
 
     Optional<Like> findByLikeId(LikeId likeId);
+    Long countByProduct(Product product);
+
+    Optional<Like> findByProduct(Product product);
 }

--- a/src/main/java/com/pinkdumbell/cocobob/domain/product/like/LikeRepository.java
+++ b/src/main/java/com/pinkdumbell/cocobob/domain/product/like/LikeRepository.java
@@ -1,0 +1,9 @@
+package com.pinkdumbell.cocobob.domain.product.like;
+
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface LikeRepository extends JpaRepository<Like,LikeId> {
+
+    Optional<Like> findByLikeId(LikeId likeId);
+}

--- a/src/main/java/com/pinkdumbell/cocobob/domain/product/like/LikeService.java
+++ b/src/main/java/com/pinkdumbell/cocobob/domain/product/like/LikeService.java
@@ -9,6 +9,7 @@ import com.pinkdumbell.cocobob.exception.CustomException;
 import com.pinkdumbell.cocobob.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @RequiredArgsConstructor
 @Service
@@ -17,7 +18,7 @@ public class LikeService {
     private final LikeRepository likeRepository;
     private final UserRepository userRepository;
     private final ProductRepository productRepository;
-
+    @Transactional
     public void like(LikeRequestDto likeRequestDto) {
 
         LikeId target = new LikeId(likeRequestDto.getUserId(), likeRequestDto.getProductId());
@@ -40,7 +41,7 @@ public class LikeService {
         likeRepository.save(like);
 
     }
-
+    @Transactional
     public void unLike(LikeRequestDto likeRequestDto) {
 
         LikeId target = new LikeId(likeRequestDto.getUserId(), likeRequestDto.getProductId());

--- a/src/main/java/com/pinkdumbell/cocobob/domain/product/like/LikeService.java
+++ b/src/main/java/com/pinkdumbell/cocobob/domain/product/like/LikeService.java
@@ -1,0 +1,67 @@
+package com.pinkdumbell.cocobob.domain.product.like;
+
+import com.pinkdumbell.cocobob.domain.product.Product;
+import com.pinkdumbell.cocobob.domain.product.ProductRepository;
+import com.pinkdumbell.cocobob.domain.product.like.dto.LikeRequestDto;
+import com.pinkdumbell.cocobob.domain.user.User;
+import com.pinkdumbell.cocobob.domain.user.UserRepository;
+import com.pinkdumbell.cocobob.exception.CustomException;
+import com.pinkdumbell.cocobob.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class LikeService {
+
+    private final LikeRepository likeRepository;
+    private final UserRepository userRepository;
+    private final ProductRepository productRepository;
+
+    public void like(LikeRequestDto likeRequestDto) {
+
+        LikeId target = new LikeId(likeRequestDto.getUserId(), likeRequestDto.getProductId());
+
+        if (likeRepository.findByLikeId(target).isPresent()) {
+            throw new CustomException(ErrorCode.ALREADY_LIKED);
+        }
+
+        User user = userRepository.findById(target.getUserId())
+            .orElseThrow(() -> {
+                throw new CustomException(ErrorCode.USER_NOT_FOUND);
+            });
+
+        Product product = productRepository.findById(target.getProductId()).orElseThrow(() -> {
+            throw new CustomException(ErrorCode.PRODUCT_NOT_FOUND);
+        });
+
+        Like like = Like.builder().user(user).product(product).likeId(target).build();
+
+        likeRepository.save(like);
+
+    }
+
+    public void unLike(LikeRequestDto likeRequestDto) {
+
+        LikeId target = new LikeId(likeRequestDto.getUserId(), likeRequestDto.getProductId());
+
+        if (likeRepository.findByLikeId(target).isEmpty()) {
+            throw new CustomException(ErrorCode.LIKE_NOT_FOUND);
+        }
+
+        User user = userRepository.findById(target.getUserId())
+            .orElseThrow(() -> {
+                throw new CustomException(ErrorCode.USER_NOT_FOUND);
+            });
+
+        Product product = productRepository.findById(target.getProductId()).orElseThrow(() -> {
+            throw new CustomException(ErrorCode.PRODUCT_NOT_FOUND);
+        });
+
+        Like like = Like.builder().user(user).product(product).likeId(target).build();
+
+        likeRepository.delete(like);
+
+    }
+
+}

--- a/src/main/java/com/pinkdumbell/cocobob/domain/product/like/LikeService.java
+++ b/src/main/java/com/pinkdumbell/cocobob/domain/product/like/LikeService.java
@@ -21,28 +21,18 @@ public class LikeService {
     @Transactional
     public void like(LikeRequestDto likeRequestDto) {
 
-        LikeId target = new LikeId(likeRequestDto.getUserId(), likeRequestDto.getProductId());
-
-        if (likeRepository.findByLikeId(target).isPresent()) {
-            throw new CustomException(ErrorCode.ALREADY_LIKED);
-        }
-
-        User user = userRepository.findById(target.getUserId())
-            .orElseThrow(() -> {
-                throw new CustomException(ErrorCode.USER_NOT_FOUND);
-            });
-
-        Product product = productRepository.findById(target.getProductId()).orElseThrow(() -> {
-            throw new CustomException(ErrorCode.PRODUCT_NOT_FOUND);
-        });
-
-        Like like = Like.builder().user(user).product(product).likeId(target).build();
-
+        Like like = makeLike(likeRequestDto);
         likeRepository.save(like);
-
     }
     @Transactional
     public void unLike(LikeRequestDto likeRequestDto) {
+
+        Like like = makeLike(likeRequestDto);
+        likeRepository.delete(like);
+    }
+
+    @Transactional
+    public Like makeLike(LikeRequestDto likeRequestDto){
 
         LikeId target = new LikeId(likeRequestDto.getUserId(), likeRequestDto.getProductId());
 
@@ -59,10 +49,7 @@ public class LikeService {
             throw new CustomException(ErrorCode.PRODUCT_NOT_FOUND);
         });
 
-        Like like = Like.builder().user(user).product(product).likeId(target).build();
-
-        likeRepository.delete(like);
-
+        return Like.builder().user(user).product(product).likeId(target).build();
     }
 
 }

--- a/src/main/java/com/pinkdumbell/cocobob/domain/product/like/dto/LikeRequestDto.java
+++ b/src/main/java/com/pinkdumbell/cocobob/domain/product/like/dto/LikeRequestDto.java
@@ -1,0 +1,11 @@
+package com.pinkdumbell.cocobob.domain.product.like.dto;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class LikeRequestDto {
+    private Long productId;
+    private Long userId;
+}

--- a/src/main/java/com/pinkdumbell/cocobob/exception/ErrorCode.java
+++ b/src/main/java/com/pinkdumbell/cocobob/exception/ErrorCode.java
@@ -20,7 +20,9 @@ public enum ErrorCode {
     FAIL_TO_UPLOAD_IMAGE(HttpStatus.INTERNAL_SERVER_ERROR, "s3 버킷에 이미지 업로드를 실패했습니다."),
     INVALID_LOGOUT_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 로그아웃 요청입니다."),
     INVALID_ACCESS_AFTER_LOGOUT(HttpStatus.BAD_REQUEST, "로그아웃된 유저 입니다."),
-    PRODUCT_NOT_FOUND(HttpStatus.BAD_REQUEST, "없는 상품 입니다.");
+    PRODUCT_NOT_FOUND(HttpStatus.BAD_REQUEST, "없는 상품 입니다."),
+    ALREADY_LIKED(HttpStatus.BAD_REQUEST, "이미 좋아요한 상품 입니다."),
+    LIKE_NOT_FOUND(HttpStatus.BAD_REQUEST, "좋아요 한적 없는 상품입니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/test/java/com/pinkdumbell/cocobob/domain/pet/PetRepositoryTest.java
+++ b/src/test/java/com/pinkdumbell/cocobob/domain/pet/PetRepositoryTest.java
@@ -1,7 +1,9 @@
 package com.pinkdumbell.cocobob.domain.pet;
 
+import com.pinkdumbell.cocobob.config.MailConfig;
 import com.pinkdumbell.cocobob.domain.pet.breed.Breed;
 import com.pinkdumbell.cocobob.domain.pet.breed.BreedRepository;
+import com.pinkdumbell.cocobob.domain.product.ProductSearchQueryDslImpl;
 import com.pinkdumbell.cocobob.domain.user.User;
 import com.pinkdumbell.cocobob.domain.user.UserRepository;
 import org.assertj.core.api.Assertions;
@@ -13,6 +15,7 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
 import java.util.Optional;
+import org.springframework.boot.test.mock.mockito.MockBean;
 
 @DataJpaTest
 public class PetRepositoryTest {
@@ -24,6 +27,8 @@ public class PetRepositoryTest {
     BreedRepository breedRepository;
     @PersistenceContext
     EntityManager em;
+    @MockBean
+    ProductSearchQueryDslImpl productSearchQueryDsl;
 
     @Test
     @DisplayName("반려동물 아이디와 사용자 이메일을 통해 반려동물 상세정보를 조회할 수 있다.")

--- a/src/test/java/com/pinkdumbell/cocobob/domain/product/ProductControllerTest.java
+++ b/src/test/java/com/pinkdumbell/cocobob/domain/product/ProductControllerTest.java
@@ -60,7 +60,6 @@ class ProductControllerTest {
     @WithMockUser("USER")
     void AAFCO_와_PAGE_SIZE_10_PAGE_NUMBER_1() throws Exception {
         //EXECUTE & EXPECT
-        // 로그인 실행
         mvc.perform(get("/v1/products/search")
                 .param("size", "10")
                 .param("page", "1")
@@ -75,7 +74,6 @@ class ProductControllerTest {
     @WithMockUser("USER")
     void AAFCO_와_PAGE_SIZE_3_PAGE_NUMBER_2() throws Exception {
         //EXECUTE & EXPECT
-        // 로그인 실행
         mvc.perform(get("/v1/products/search")
                 .param("size", "3")
                 .param("page", "2")
@@ -84,4 +82,5 @@ class ProductControllerTest {
             .andExpect(jsonPath("$.data.pageSize").value(3))
             .andExpect(jsonPath("$.data.pageNumber").value(2));
     }
+
 }

--- a/src/test/java/com/pinkdumbell/cocobob/domain/product/ProductControllerTest.java
+++ b/src/test/java/com/pinkdumbell/cocobob/domain/product/ProductControllerTest.java
@@ -63,7 +63,7 @@ class ProductControllerTest {
         mvc.perform(get("/v1/products/search")
                 .param("size", "10")
                 .param("page", "1")
-            .param("AAFCO", "true"))
+            .param("aaffo", "true"))
             .andExpect(status().is2xxSuccessful())
             .andExpect(jsonPath("$.data.pageSize").value(10))
             .andExpect(jsonPath("$.data.pageNumber").value(1));
@@ -77,7 +77,7 @@ class ProductControllerTest {
         mvc.perform(get("/v1/products/search")
                 .param("size", "3")
                 .param("page", "2")
-                .param("AAFCO", "true"))
+                .param("aaffo", "true"))
             .andExpect(status().is2xxSuccessful())
             .andExpect(jsonPath("$.data.pageSize").value(3))
             .andExpect(jsonPath("$.data.pageNumber").value(2));

--- a/src/test/java/com/pinkdumbell/cocobob/domain/product/ProductRepositoryTest.java
+++ b/src/test/java/com/pinkdumbell/cocobob/domain/product/ProductRepositoryTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
@@ -19,6 +20,9 @@ class ProductRepositoryTest {
     @Autowired
     private ProductRepository productRepository;
 
+    @MockBean
+    ProductSearchQueryDslImpl productSearchQueryDsl;
+
     @BeforeEach
     void init() {
         for (int dummyIndex = 1; dummyIndex < 30; dummyIndex++) {
@@ -29,7 +33,8 @@ class ProductRepositoryTest {
 
     @Test
     @DisplayName("사용자가 요청한 상품 코드로 상품의 상세 정보 조회가 가능해야 한다.")
-    void findProductDetailById() {
+    void
+    findProductDetailById() {
 
         //ProductId 10을 가지고 있는 상품 조회
         Product result = productRepository.findById(10L).get();

--- a/src/test/java/com/pinkdumbell/cocobob/domain/product/ProductServiceTest.java
+++ b/src/test/java/com/pinkdumbell/cocobob/domain/product/ProductServiceTest.java
@@ -1,0 +1,68 @@
+package com.pinkdumbell.cocobob.domain.product;
+
+import static org.mockito.BDDMockito.*;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo.As;
+import com.pinkdumbell.cocobob.domain.product.dto.ProductDetailResponseDto;
+import com.pinkdumbell.cocobob.domain.product.like.Like;
+import com.pinkdumbell.cocobob.domain.product.like.LikeRepository;
+import com.pinkdumbell.cocobob.domain.user.User;
+import com.pinkdumbell.cocobob.domain.user.UserRepository;
+import java.util.Optional;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ProductServiceTest {
+
+    @InjectMocks
+    ProductService productService;
+
+    @Mock
+    ProductRepository productRepository;
+
+    @Mock
+    UserRepository userRepository;
+
+    @Mock
+    LikeRepository likeRepository;
+
+    @Test
+    @DisplayName("상품 아이디와 유저 이메일을 통해서 상품의 상세정보와 유저의 좋아요와 총 좋아요수를 파악할 수 있다.")
+    void find_product_detail_with_user_email_and_product_id() {
+        String userEmail = "test@test.com";
+        Long productId = 1L;
+
+        //when
+        Product expectedProduct = Product.builder().id(productId).build();
+        User expectedUser = User.builder().email(userEmail).build();
+        Like expectedLike = Like.builder().user(expectedUser).product(expectedProduct).build();
+
+        given(productRepository.findById(anyLong())).willReturn(
+            Optional.ofNullable(expectedProduct));
+
+        given(userRepository.findByEmail(userEmail)).willReturn(Optional.ofNullable(expectedUser));
+
+        given(likeRepository.countByProduct(any(Product.class))).willReturn(100L);
+
+        given(likeRepository.findByProductAndUser(any(Product.class),any(User.class))).willReturn(Optional.ofNullable(expectedLike));
+
+        //Execute
+        ProductDetailResponseDto result = productService.findProductDetailById(productId,
+            userEmail);
+
+        Assertions.assertThat(result.getLikes()).isEqualTo(100L);
+        Assertions.assertThat(result.getIsUserLike()).isEqualTo(true);
+
+
+    }
+
+    @Test
+    void queryDslSearchProducts() {
+    }
+}

--- a/src/test/java/com/pinkdumbell/cocobob/domain/user/UserRepositoryTest.java
+++ b/src/test/java/com/pinkdumbell/cocobob/domain/user/UserRepositoryTest.java
@@ -7,10 +7,12 @@ import com.pinkdumbell.cocobob.domain.pet.breed.Breed;
 import com.pinkdumbell.cocobob.domain.pet.breed.BreedRepository;
 import com.pinkdumbell.cocobob.domain.pet.image.PetImage;
 import com.pinkdumbell.cocobob.domain.pet.image.PetImageRepository;
+import com.pinkdumbell.cocobob.domain.product.ProductSearchQueryDslImpl;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.assertj.core.api.Assertions;
 
@@ -25,6 +27,7 @@ import java.util.stream.Collectors;
 @DataJpaTest
 @Import(JpaAuditingConfig.class)
 public class UserRepositoryTest {
+
     @Autowired
     UserRepository userRepository;
     @Autowired
@@ -35,6 +38,8 @@ public class UserRepositoryTest {
     BreedRepository breedRepository;
     @PersistenceContext
     EntityManager em;
+    @MockBean
+    ProductSearchQueryDslImpl productSearchQueryDsl;
 
     @Test
     @DisplayName("사용자 생성 시 생성시간 등록 여부를 테스트한다.")
@@ -54,25 +59,25 @@ public class UserRepositoryTest {
         String name = "코코";
 
         User user = userRepository.save(User.builder()
-                .email(email)
-                .build());
+            .email(email)
+            .build());
 
         Pet pet1 = Pet.builder()
-                .user(user)
-                .name(name)
-                .build();
+            .user(user)
+            .name(name)
+            .build();
         pet1.setThumbnailPath(thumbnailPath);
 
         Pet pet2 = Pet.builder()
-                .user(user)
-                .name("키키")
-                .build();
+            .user(user)
+            .name("키키")
+            .build();
         pet2.setThumbnailPath(thumbnailPath);
 
         PetImage petImage = PetImage.builder()
-                .pet(pet1)
-                .path("imagePath")
-                .build();
+            .pet(pet1)
+            .path("imagePath")
+            .build();
 
         petRepository.save(pet1);
         petRepository.save(pet2);
@@ -93,18 +98,18 @@ public class UserRepositoryTest {
         String email = "test@test.com";
         User user = userRepository.save(User.builder().email(email).build());
         Breed breed = breedRepository.save(Breed.builder()
-                .name("진돗개")
-                .build());
+            .name("진돗개")
+            .build());
         petRepository.save(Pet.builder()
-                .user(user)
-                .breed(breed)
-                .name("코코")
-                .build());
+            .user(user)
+            .breed(breed)
+            .name("코코")
+            .build());
         petRepository.save(Pet.builder()
-                .user(user)
-                .breed(breed)
-                .name("키키")
-                .build());
+            .user(user)
+            .breed(breed)
+            .name("키키")
+            .build());
 
         em.flush();
         em.clear();
@@ -113,8 +118,9 @@ public class UserRepositoryTest {
         List<Pet> pets = result.get().getPets();
         Assertions.assertThat(pets.size()).isEqualTo(2);
         Assertions.assertThat(pets.stream().map(Pet::getName).collect(Collectors.toList()))
-                .isEqualTo(Arrays.asList("코코", "키키"));
-        Assertions.assertThat(pets.stream().map(Pet::getBreed).map(Breed::getName).collect(Collectors.toList()))
-                .isEqualTo(Arrays.asList("진돗개", "진돗개"));
+            .isEqualTo(Arrays.asList("코코", "키키"));
+        Assertions.assertThat(
+                pets.stream().map(Pet::getBreed).map(Breed::getName).collect(Collectors.toList()))
+            .isEqualTo(Arrays.asList("진돗개", "진돗개"));
     }
 }


### PR DESCRIPTION
[CB-285] QueryDsl이 적용되지 않음

🔨 Jira 태스크
- [CB-287] 좋아요 기능이 없음
- QueryDSL이 적용되지 않음


📐 구현한 내용
- 좋아요 기능 추가
- 기존 criteria로만 구현할시 join하는 것에 큰 어려움이 있어 좋아요를 표시할 경우 DB 쿼리가 과도하게 발생한다. 그래서 이를 QueryDSL을 사용하여 쿼리수를 적게 사용하였다.
- QueryDSL을 이용하여 상품 목록화시 좋아요수를 확인할 수 있게 하였다.
- QueryDSL을 이용하여 현재 사용자가 좋아요 누른 상품을 볼 수 있게 하였다.
- 상품ID, 가격, 좋아요를 기준으로 상품 목록을 정렬할 수 있도록 하였다.


🚧 논의 사항
- 쿼리 수는 줄었지만 쿼리의 복잡성은 증가



[CB-285]: https://cocobob.atlassian.net/browse/CB-285?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CB-287]: https://cocobob.atlassian.net/browse/CB-287?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ