### PR TITLE
CB-309 [fix]: add googleOauthInfo & kakaoOauthInfo for test

### DIFF
--- a/src/test/java/com/pinkdumbell/cocobob/domain/product/ProductControllerTest.java
+++ b/src/test/java/com/pinkdumbell/cocobob/domain/product/ProductControllerTest.java
@@ -9,6 +9,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.pinkdumbell.cocobob.common.EmailUtil;
 import com.pinkdumbell.cocobob.config.MailConfig;
+import com.pinkdumbell.cocobob.domain.auth.GoogleOauthInfo;
+import com.pinkdumbell.cocobob.domain.auth.KakaoOauthInfo;
 import javax.transaction.Transactional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -47,16 +49,11 @@ class ProductControllerTest {
     @Autowired
     private WebApplicationContext context;
 
-    @Value("${google.auth.url}")
-    private String googleAuthUrl;
-    @Value("${google.login.url}")
-    private String googleLoginUrl;
-    @Value("${google.client.id}")
-    private String googleClientId;
-    @Value("${google.client.secret}")
-    private String googleClientSecret;
-    @Value("${google.redirect.url}")
-    private String googleRedirectUrl;
+    @MockBean
+    GoogleOauthInfo googleOauthInfo;
+
+    @MockBean
+    KakaoOauthInfo kakaoOauthInfo;
     MockMvc mvc;
 
     @BeforeEach

--- a/src/test/java/com/pinkdumbell/cocobob/domain/user/UserControllerTest.java
+++ b/src/test/java/com/pinkdumbell/cocobob/domain/user/UserControllerTest.java
@@ -10,7 +10,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.pinkdumbell.cocobob.common.EmailUtil;
 import com.pinkdumbell.cocobob.config.MailConfig;
+import com.pinkdumbell.cocobob.domain.auth.GoogleOauthInfo;
 import com.pinkdumbell.cocobob.domain.auth.JwtTokenProvider;
+import com.pinkdumbell.cocobob.domain.auth.KakaoOauthInfo;
 import com.pinkdumbell.cocobob.domain.user.dto.UserCreateRequestDto;
 import com.pinkdumbell.cocobob.domain.user.dto.UserCreateResponseDto;
 
@@ -63,16 +65,12 @@ class UserControllerTest {
     MailConfig mailConfig;
     @Value("${spring.jwt.secretKey}")
     private String secretKey;
-    @Value("${google.auth.url}")
-    private String googleAuthUrl;
-    @Value("${google.login.url}")
-    private String googleLoginUrl;
-    @Value("${google.client.id}")
-    private String googleClientId;
-    @Value("${google.client.secret}")
-    private String googleClientSecret;
-    @Value("${google.redirect.url}")
-    private String googleRedirectUrl;
+
+    @MockBean
+    GoogleOauthInfo googleOauthInfo;
+
+    @MockBean
+    KakaoOauthInfo kakaoOauthInfo;
 
 
     @Autowired

--- a/src/test/java/com/pinkdumbell/cocobob/domain/user/UserControllerUnitTest.java
+++ b/src/test/java/com/pinkdumbell/cocobob/domain/user/UserControllerUnitTest.java
@@ -1,7 +1,9 @@
 package com.pinkdumbell.cocobob.domain.user;
 
 import com.pinkdumbell.cocobob.config.annotation.loginuser.LoginUserArgumentResolver;
+import com.pinkdumbell.cocobob.domain.auth.GoogleOauthInfo;
 import com.pinkdumbell.cocobob.domain.auth.JwtTokenProvider;
+import com.pinkdumbell.cocobob.domain.auth.KakaoOauthInfo;
 import com.pinkdumbell.cocobob.domain.pet.dto.SimplePetInfoDto;
 import com.pinkdumbell.cocobob.domain.user.dto.LoginUserInfo;
 import com.pinkdumbell.cocobob.domain.user.dto.UserGetResponseDto;
@@ -40,6 +42,10 @@ public class UserControllerUnitTest {
     JwtTokenProvider jwtTokenProvider;
     @MockBean
     LoginUserArgumentResolver loginUserArgumentResolver;
+    @MockBean
+    GoogleOauthInfo googleOauthInfo;
+    @MockBean
+    KakaoOauthInfo kakaoOauthInfo;
 
     @BeforeEach
     void setUp() {

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -52,3 +52,11 @@ google:
   client:
     id: test
     secret: test
+
+kakao:
+  client_id: test
+  redirect: test
+  url:
+    login: test
+    token: test
+    profile: test


### PR DESCRIPTION


[CB-309]

🔨 Jira 태스크
새로 생성된 구글, 카카오 정보를 담는 컴포넌트로 인해 발생하는 테스트 에러 해결


📐 구현한 내용
테스트 에러 해결


🚧 논의 사항




[CB-309]: https://cocobob.atlassian.net/browse/CB-309?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ