### PR TITLE
[CB-332] [BE] 사용자 반려동물의 연관관계 때문에 서로 참조하여 삭제할 수 없음

### DIFF
--- a/src/main/java/com/pinkdumbell/cocobob/domain/pet/PetService.java
+++ b/src/main/java/com/pinkdumbell/cocobob/domain/pet/PetService.java
@@ -42,8 +42,8 @@ public class PetService {
         User user = userRepository.findByEmail(loginUserInfo.getEmail())
             .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
         Pet pet = savePet(requestDto, user);
-        Optional<Pet> representativePet = Optional.ofNullable(user.getRepresentativePet());
-        if (representativePet.isEmpty()) {
+
+        if (user.getRepresentativePetId() == null) {
             user.updateRepresentativePet(pet);
         }
         saveImage(requestDto.getPetImage(), pet);

--- a/src/main/java/com/pinkdumbell/cocobob/domain/user/User.java
+++ b/src/main/java/com/pinkdumbell/cocobob/domain/user/User.java
@@ -31,9 +31,7 @@ public class User extends BaseEntity {
     @Enumerated(value = EnumType.STRING)
     private AccountType accountType;
 
-    @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "representative_pet_id")
-    private Pet representativePet;
+    private Long representativePetId;
     @Enumerated(value = EnumType.STRING)
     private UserRole role;
 
@@ -65,7 +63,7 @@ public class User extends BaseEntity {
     }
 
     public void updateRepresentativePet(Pet pet) {
-        this.representativePet = pet;
+        this.representativePetId = pet.getId();
     }
 
     public void updatePassword(String newPassword){

--- a/src/main/java/com/pinkdumbell/cocobob/domain/user/dto/UserGetResponseDto.java
+++ b/src/main/java/com/pinkdumbell/cocobob/domain/user/dto/UserGetResponseDto.java
@@ -25,8 +25,8 @@ public class UserGetResponseDto {
         this.name = entity.getUsername();
         this.email = entity.getEmail();
         this.pets = entity.getPets().stream().map(SimplePetInfoDto::new).collect(Collectors.toList());
-        if (entity.getRepresentativePet() != null) {
-            this.representativeAnimalId = entity.getRepresentativePet().getId();
+        if (entity.getRepresentativePetId() != null) {
+            this.representativeAnimalId = entity.getRepresentativePetId();
         } else {
             this.representativeAnimalId = null;
         }

--- a/src/main/resources/db/migration/V8__drop_relation_between_user_with_representativepet.sql
+++ b/src/main/resources/db/migration/V8__drop_relation_between_user_with_representativepet.sql
@@ -1,0 +1,1 @@
+alter table user drop foreign key user_ibfk_1;


### PR DESCRIPTION
[CB-332]

🔨 Jira 태스크
[CB-332] 사용자 반려동물의 연관관계 때문에 서로 참조하여 삭제할 수 없음


📐 구현한 내용
- 사용자와 대표 반려동물 연관관계(1:1) 삭제
- 사용자 엔티티에서 대표 반려동물 id를 연관관계 없이 가질 수 있도록 수정
- 외래키 제약 수정에 따른 flyway script 작성


🚧 논의 사항




[CB-332]: https://cocobob.atlassian.net/browse/CB-332?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CB-332]: https://cocobob.atlassian.net/browse/CB-332?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ