### PR TITLE
CB357 be 좋아요 기능 사용시 user id 사용 불필요함

### DIFF
--- a/src/main/java/com/pinkdumbell/cocobob/config/SwaggerConfig.java
+++ b/src/main/java/com/pinkdumbell/cocobob/config/SwaggerConfig.java
@@ -1,5 +1,6 @@
 package com.pinkdumbell.cocobob.config;
 
+import com.pinkdumbell.cocobob.domain.user.dto.LoginUserInfo;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -33,7 +34,7 @@ public class SwaggerConfig {
     @Bean
     public Docket swaggerApi() {
         return new Docket(DocumentationType.OAS_30)
-            .ignoredParameterTypes(Pageable.class)
+            .ignoredParameterTypes(Pageable.class, LoginUserInfo.class)
             .useDefaultResponseMessages(false)
             .securityContexts(Arrays.asList(securityContext()))
             .securitySchemes(Arrays.asList(apiKey()))

--- a/src/main/java/com/pinkdumbell/cocobob/domain/product/like/LikeController.java
+++ b/src/main/java/com/pinkdumbell/cocobob/domain/product/like/LikeController.java
@@ -1,8 +1,10 @@
 package com.pinkdumbell.cocobob.domain.product.like;
 
 import com.pinkdumbell.cocobob.common.dto.CommonResponseDto;
+import com.pinkdumbell.cocobob.config.annotation.loginuser.LoginUser;
 import com.pinkdumbell.cocobob.domain.product.dto.FindAllResponseDto;
 import com.pinkdumbell.cocobob.domain.product.like.dto.LikeRequestDto;
+import com.pinkdumbell.cocobob.domain.user.dto.LoginUserInfo;
 import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -23,9 +25,9 @@ public class LikeController {
 
 
     @PostMapping("")
-    public ResponseEntity<CommonResponseDto> like(@RequestBody LikeRequestDto likeRequestDto) {
+    public ResponseEntity<CommonResponseDto> like(@LoginUser LoginUserInfo loginUserInfo,@RequestBody LikeRequestDto likeRequestDto) {
 
-        likeService.like(likeRequestDto);
+        likeService.like(likeRequestDto,loginUserInfo);
 
         return ResponseEntity.ok(CommonResponseDto.builder()
             .status(HttpStatus.OK.value()).
@@ -36,9 +38,9 @@ public class LikeController {
     }
 
     @DeleteMapping("")
-    public ResponseEntity<CommonResponseDto> unLike(@RequestBody LikeRequestDto likeRequestDto) {
+    public ResponseEntity<CommonResponseDto> unLike(@LoginUser LoginUserInfo loginUserInfo,@RequestBody LikeRequestDto likeRequestDto) {
 
-        likeService.unLike(likeRequestDto);
+        likeService.unLike(likeRequestDto,loginUserInfo);
 
         return ResponseEntity.ok(CommonResponseDto.builder()
             .status(HttpStatus.OK.value()).

--- a/src/main/java/com/pinkdumbell/cocobob/domain/product/like/LikeService.java
+++ b/src/main/java/com/pinkdumbell/cocobob/domain/product/like/LikeService.java
@@ -5,8 +5,10 @@ import com.pinkdumbell.cocobob.domain.product.ProductRepository;
 import com.pinkdumbell.cocobob.domain.product.like.dto.LikeRequestDto;
 import com.pinkdumbell.cocobob.domain.user.User;
 import com.pinkdumbell.cocobob.domain.user.UserRepository;
+import com.pinkdumbell.cocobob.domain.user.dto.LoginUserInfo;
 import com.pinkdumbell.cocobob.exception.CustomException;
 import com.pinkdumbell.cocobob.exception.ErrorCode;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -20,9 +22,13 @@ public class LikeService {
     private final ProductRepository productRepository;
 
     @Transactional
-    public void like(LikeRequestDto likeRequestDto) {
+    public void like(LikeRequestDto likeRequestDto, LoginUserInfo loginUserInfo) {
 
-        LikeId target = new LikeId(likeRequestDto.getUserId(), likeRequestDto.getProductId());
+        User user = userRepository.findByEmail(loginUserInfo.getEmail()).orElseThrow(() -> {
+            throw new CustomException(ErrorCode.USER_NOT_FOUND);
+        });
+
+        LikeId target = new LikeId(user.getId(), likeRequestDto.getProductId());
 
         if (likeRepository.findByLikeId(target).isPresent()) {
             throw new CustomException(ErrorCode.ALREADY_LIKED);
@@ -34,9 +40,13 @@ public class LikeService {
     }
 
     @Transactional
-    public void unLike(LikeRequestDto likeRequestDto) {
+    public void unLike(LikeRequestDto likeRequestDto,LoginUserInfo loginUserInfo) {
 
-        LikeId target = new LikeId(likeRequestDto.getUserId(), likeRequestDto.getProductId());
+        User user = userRepository.findByEmail(loginUserInfo.getEmail()).orElseThrow(() -> {
+            throw new CustomException(ErrorCode.USER_NOT_FOUND);
+        });
+
+        LikeId target = new LikeId(user.getId(), likeRequestDto.getProductId());
 
         if (likeRepository.findByLikeId(target).isEmpty()) {
             throw new CustomException(ErrorCode.LIKE_NOT_FOUND);

--- a/src/main/java/com/pinkdumbell/cocobob/domain/product/like/dto/LikeRequestDto.java
+++ b/src/main/java/com/pinkdumbell/cocobob/domain/product/like/dto/LikeRequestDto.java
@@ -7,5 +7,4 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class LikeRequestDto {
     private Long productId;
-    private Long userId;
 }


### PR DESCRIPTION
[CB-357]

🔨 Jira 태스크
좋아요 기능시 userId입력을 생략할 수 있도록 함


📐 구현한 내용
토큰을 통해서 user 정보를 파악할 수 있기에 클라이언트에게 추가로 user 정보를 받기 보다는 기존에 개발한 loginuser 어노테이션으로 해결할 수 있게 하였습니다.

또한, LoginUserInfo는 클라이언트에서 입력할 필요 없는 값이기에, swagger에서 표시되는 것을 방지하였습니다.


🚧 논의 사항




[CB-357]: https://cocobob.atlassian.net/browse/CB-357?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ