### PR TITLE
[CB-369] fix : 쓸모없는 트리거 삭제

### DIFF
--- a/src/main/resources/db/migration/V13__drop_useless_trigger_when_pet_deleted.sql
+++ b/src/main/resources/db/migration/V13__drop_useless_trigger_when_pet_deleted.sql
@@ -1,0 +1,1 @@
+drop trigger pet;


### PR DESCRIPTION
[CB-369]

🔨 Jira 태스크
[CB-369] [BE] 반려동물 삭제 시 삭제되지 않게 하는 DB 레벨의 트리거 삭제가 필요함


📐 구현한 내용
- flyway script를 통해 반려동물 삭제 시 deleted 값을 update하는 트리거 삭제
  - 엔티티의 @SqlDelete 어노테이션을 통해 바뀐 쿼리가 나가서 디비 레벨의 트리거가 필요없다고 판단

🚧 논의 사항




[CB-369]: https://cocobob.atlassian.net/browse/CB-369?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CB-369]: https://cocobob.atlassian.net/browse/CB-369?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ