### PR TITLE
Cb 370 상품 키워드 제공 api가 없음

### DIFF
--- a/src/main/java/com/pinkdumbell/cocobob/domain/product/ProductController.java
+++ b/src/main/java/com/pinkdumbell/cocobob/domain/product/ProductController.java
@@ -5,6 +5,7 @@ import com.pinkdumbell.cocobob.config.annotation.loginuser.LoginUser;
 import com.pinkdumbell.cocobob.domain.pet.PetService;
 import com.pinkdumbell.cocobob.domain.product.dto.FindAllResponseDto;
 import com.pinkdumbell.cocobob.domain.product.dto.ProductDetailResponseDto;
+import com.pinkdumbell.cocobob.domain.product.dto.ProductKeywordDto;
 import com.pinkdumbell.cocobob.domain.product.dto.ProductSpecificSearchDto;
 import com.pinkdumbell.cocobob.domain.product.dto.ProductSpecificSearchWithLikeDto;
 import com.pinkdumbell.cocobob.domain.user.dto.LoginUserInfo;
@@ -18,7 +19,6 @@ import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 
-import javax.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.data.domain.Pageable;
@@ -27,7 +27,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @ApiOperation("Product API")
@@ -53,6 +52,15 @@ public class ProductController {
 
         public ProductDetailResponseClass(int status, String code, String message,
             ProductDetailResponseDto data) {
+            super(status, code, message, data);
+        }
+    }
+
+    private static class ProductKeywordResponseClass extends
+        CommonResponseDto<ProductKeywordDto> {
+
+        public ProductKeywordResponseClass(int status, String code, String message,
+            ProductKeywordDto data) {
             super(status, code, message, data);
         }
     }
@@ -194,6 +202,16 @@ public class ProductController {
                 "찜한 상품 불러오기 성공",
                 productService.findAllWishList(loginUserInfo.getEmail(), pageable)));
 
+    }
+
+    @GetMapping("/keyword")
+    public ResponseEntity<ProductKeywordResponseClass> getProductsKeyword(String keyword) {
+
+        return ResponseEntity.ok(
+            new ProductKeywordResponseClass(HttpStatus.OK.value(),
+                "SUCCESS LOAD KEYWORD",
+                "연관 검색어 불러오기 성공",
+                productService.getKeyword(keyword)));
     }
 
 }

--- a/src/main/java/com/pinkdumbell/cocobob/domain/product/ProductPredicate.java
+++ b/src/main/java/com/pinkdumbell/cocobob/domain/product/ProductPredicate.java
@@ -120,4 +120,14 @@ public class ProductPredicate {
         return builder;
     }
 
+    public static BooleanBuilder makeKeywordBooleanBuilder(String keyword) {
+        BooleanBuilder builder = new BooleanBuilder();
+        QProduct qProduct = QProduct.product;
+
+        builder.or(qProduct.brand.contains(keyword));
+        builder.or(qProduct.name.contains(keyword));
+
+        return builder;
+    }
+
 }

--- a/src/main/java/com/pinkdumbell/cocobob/domain/product/ProductSearchQueryDsl.java
+++ b/src/main/java/com/pinkdumbell/cocobob/domain/product/ProductSearchQueryDsl.java
@@ -12,4 +12,6 @@ public interface ProductSearchQueryDsl {
 
     PageImpl<ProductSimpleResponseDto> findAllWithLikes(
         ProductSpecificSearchWithLikeDto productSpecificSearchDto, Long userId);
+
+    List<String> findProductNamesByKeyword(String keyword);
 }

--- a/src/main/java/com/pinkdumbell/cocobob/domain/product/ProductService.java
+++ b/src/main/java/com/pinkdumbell/cocobob/domain/product/ProductService.java
@@ -3,6 +3,7 @@ package com.pinkdumbell.cocobob.domain.product;
 import com.pinkdumbell.cocobob.domain.product.dto.FindAllResponseDto;
 import com.pinkdumbell.cocobob.domain.product.dto.ProductDetailResponseDto;
 
+import com.pinkdumbell.cocobob.domain.product.dto.ProductKeywordDto;
 import com.pinkdumbell.cocobob.domain.product.dto.ProductSpecificSearchDto;
 import com.pinkdumbell.cocobob.domain.product.dto.ProductSpecificSearchWithLikeDto;
 import com.pinkdumbell.cocobob.domain.product.like.LikeRepository;
@@ -15,7 +16,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.data.domain.Pageable;
 
 @RequiredArgsConstructor
 @Service
@@ -70,5 +70,9 @@ public class ProductService {
         });
 
         return new FindAllResponseDto(likeRepository.findAllByUserLike(user, pageable));
+    }
+
+    public ProductKeywordDto getKeyword(String keyword) {
+        return new ProductKeywordDto(productRepository.findProductNamesByKeyword(keyword));
     }
 }

--- a/src/main/java/com/pinkdumbell/cocobob/domain/product/dto/ProductKeywordDto.java
+++ b/src/main/java/com/pinkdumbell/cocobob/domain/product/dto/ProductKeywordDto.java
@@ -1,0 +1,21 @@
+package com.pinkdumbell.cocobob.domain.product.dto;
+
+import io.swagger.annotations.ApiModelProperty;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Getter
+@Setter
+public class ProductKeywordDto {
+
+    @ApiModelProperty(notes = "상품 리스트", example = "[펫 더 리얼, 리얼, ...]")
+    private List<String> names;
+
+}

--- a/src/main/resources/db/migration/V13__replace_blank_from_proudct_brand.sql
+++ b/src/main/resources/db/migration/V13__replace_blank_from_proudct_brand.sql
@@ -1,0 +1,4 @@
+update product
+SET brand = REPLACE(brand, ' ', '');
+update product
+SET name = REPLACE(name, ' ', '');


### PR DESCRIPTION
[CB-370]

🔨 Jira 태스크
상품 키워드 제공 API가 없음

📐 구현한 내용
- 상품 키워드 전송시 브랜드명과 상품명에 키워드가 들어가 있는 상품 이름 제공
- 상품 설명 키워드는 제외(업체에 동일한 설명으로 인해 다른 재료명이거나 다른 종류에도 검색되는 경우가 발생)

🚧 논의 사항
- 더욱 유연한 검색 방식 고안



[CB-370]: https://cocobob.atlassian.net/browse/CB-370?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ