### PR TITLE
Cb 370 상품 키워드 제공 api가 없음

### DIFF
--- a/src/main/java/com/pinkdumbell/cocobob/domain/product/ProductController.java
+++ b/src/main/java/com/pinkdumbell/cocobob/domain/product/ProductController.java
@@ -204,6 +204,17 @@ public class ProductController {
 
     }
 
+    @ApiOperation(value = "getProductsKeyword", notes = "연관된 검색어 목록 제공")
+    @ApiResponses(value = {
+        @ApiResponse(code = 200, message = "", response = ProductKeywordResponseClass.class),
+        @ApiResponse(code = 400, message = "", response = ErrorResponse.class),
+        @ApiResponse(code = 500, message = "INTERNAL SERVER ERROR", response = ErrorResponse.class)
+
+    })
+    @ApiImplicitParams({
+        @ApiImplicitParam(name = "keyword", dataType = "String", paramType = "query",
+            value = "검색 keyword"),
+    })
     @GetMapping("/keyword")
     public ResponseEntity<ProductKeywordResponseClass> getProductsKeyword(String keyword) {
 

--- a/src/main/resources/db/migration/V13__replace_blank_from_proudct_brand.sql
+++ b/src/main/resources/db/migration/V13__replace_blank_from_proudct_brand.sql
@@ -1,4 +1,0 @@
-update product
-SET brand = REPLACE(brand, ' ', '');
-update product
-SET name = REPLACE(name, ' ', '');

--- a/src/main/resources/db/migration/V13__replace_blank_from_proudct_brand.sql
+++ b/src/main/resources/db/migration/V13__replace_blank_from_proudct_brand.sql
@@ -1,0 +1,4 @@
+update product
+SET brand = REPLACE(brand, ' ', '');
+update product
+SET name = REPLACE(name, ' ', '');

--- a/src/test/java/com/pinkdumbell/cocobob/config/TestConfig.java
+++ b/src/test/java/com/pinkdumbell/cocobob/config/TestConfig.java
@@ -1,0 +1,19 @@
+package com.pinkdumbell.cocobob.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+
+@TestConfiguration
+public class TestConfig {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/test/java/com/pinkdumbell/cocobob/domain/product/ProductRepositoryTest.java
+++ b/src/test/java/com/pinkdumbell/cocobob/domain/product/ProductRepositoryTest.java
@@ -1,6 +1,10 @@
 package com.pinkdumbell.cocobob.domain.product;
 
 
+import com.pinkdumbell.cocobob.config.TestConfig;
+import com.querydsl.core.Tuple;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -8,13 +12,12 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Sort;
+import org.springframework.context.annotation.Import;
 import org.springframework.transaction.annotation.Transactional;
 
 @DataJpaTest
 @Transactional
+@Import(TestConfig.class)
 class ProductRepositoryTest {
 
     @Autowired
@@ -22,6 +25,9 @@ class ProductRepositoryTest {
 
     @MockBean
     ProductSearchQueryDslImpl productSearchQueryDsl;
+
+    @Autowired
+    JPAQueryFactory jpaQueryFactory;
 
     @BeforeEach
     void init() {
@@ -33,12 +39,24 @@ class ProductRepositoryTest {
 
     @Test
     @DisplayName("사용자가 요청한 상품 코드로 상품의 상세 정보 조회가 가능해야 한다.")
-    void
-    findProductDetailById() {
+    void findProductDetailById() {
 
         //ProductId 10을 가지고 있는 상품 조회
         Product result = productRepository.findById(10L).get();
 
         Assertions.assertThat(result.getId()).isEqualTo(10L);
     }
+
+    @Test
+    @DisplayName("keyword를 통한 연관 상품 정보를 제공할 수 있어야 한다.")
+    void provideProductListByKeyword() {
+        QProduct qProduct = QProduct.product;
+
+        List<Tuple> result = jpaQueryFactory.select(qProduct.brand, qProduct.name)
+            .from(qProduct)
+            .where(ProductPredicate.makeKeywordBooleanBuilder("test"))
+            .fetch();
+        Assertions.assertThat(result).isNotNull();
+    }
+
 }


### PR DESCRIPTION
[CB-370]

🔨 Jira 태스크
- 상품 키워드 제공 API 가 없음


📐 구현한 내용
- Swagger 명세서 작성
- Test 코드 작성
- 불필요한 flyway vesrsion 13 삭제



🚧 논의 사항




[CB-370]: https://cocobob.atlassian.net/browse/CB-370?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ