### PR TITLE
Cb 370 상품 키워드 제공 api가 없음

### DIFF
--- a/src/main/java/com/pinkdumbell/cocobob/domain/product/ProductController.java
+++ b/src/main/java/com/pinkdumbell/cocobob/domain/product/ProductController.java
@@ -30,7 +30,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @ApiOperation("Product API")
-@RequestMapping("/v1/products")
 @RequiredArgsConstructor
 @RestController
 public class ProductController {
@@ -72,7 +71,7 @@ public class ProductController {
         @ApiResponse(code = 500, message = "INTERNAL SERVER ERROR", response = ErrorResponse.class)
 
     })
-    @GetMapping("/{productId}")
+    @GetMapping("/v1/products/{productId}")
     public ResponseEntity<ProductDetailResponseClass> productDetail(@PathVariable Long productId,
         @LoginUser LoginUserInfo loginUserInfo) {
 
@@ -97,7 +96,7 @@ public class ProductController {
         @ApiImplicitParam(name = "sort", allowMultiple = true, dataType = "string", paramType = "query",
             value = "정렬(사용법: 컬럼명,ASC|DESC)")
     })
-    @GetMapping("/search")
+    @GetMapping("/v1/products/search")
     public ResponseEntity<ProvideAllResponseClass> searchAllProducts(
         ProductSpecificSearchDto productSpecificSearchDto, Pageable pageable) {
 
@@ -122,7 +121,7 @@ public class ProductController {
         @ApiImplicitParam(name = "sort", dataType = "string", paramType = "query",
             value = "정렬(사용법: 컬럼명,ASC|DESC)")
     })
-    @GetMapping("/search/likes")
+    @GetMapping("/v2/products/search")
     public ResponseEntity<ProvideAllResponseClass> searchAllProductsWithLikes(
         ProductSpecificSearchWithLikeDto productSpecificSearchWithLikeDto,
         @LoginUser LoginUserInfo loginUserInfo) {
@@ -145,7 +144,7 @@ public class ProductController {
         @ApiImplicitParam(name = "sort", dataType = "string", paramType = "query",
             value = "정렬(사용법: 컬럼명,ASC|DESC)"),
     })
-    @GetMapping("/recommendation/{type}")
+    @GetMapping("/v1/products/recommendation/{type}")
     public ResponseEntity<ProvideAllResponseClass> recommendWithAge(Long petId, Integer page,
         Integer size, String sort, @LoginUser LoginUserInfo loginUserInfo,
         @PathVariable String type) {
@@ -192,7 +191,7 @@ public class ProductController {
         @ApiImplicitParam(name = "petId", dataType = "integer", paramType = "query",
             value = "반려동물 Id"),
     })
-    @GetMapping("/wishlist")
+    @GetMapping("/v1/products/wishlist")
     public ResponseEntity<ProvideAllResponseClass> provideWishList(
         @LoginUser LoginUserInfo loginUserInfo, Pageable pageable) {
 
@@ -215,8 +214,12 @@ public class ProductController {
         @ApiImplicitParam(name = "keyword", dataType = "String", paramType = "query",
             value = "검색 keyword"),
     })
-    @GetMapping("/keyword")
+    @GetMapping("/v1/products/keyword")
     public ResponseEntity<ProductKeywordResponseClass> getProductsKeyword(String keyword) {
+
+        if (keyword == null) {
+            throw new CustomException(ErrorCode.BAD_REQUEST);
+        }
 
         return ResponseEntity.ok(
             new ProductKeywordResponseClass(HttpStatus.OK.value(),

--- a/src/main/java/com/pinkdumbell/cocobob/domain/product/ProductPredicate.java
+++ b/src/main/java/com/pinkdumbell/cocobob/domain/product/ProductPredicate.java
@@ -126,6 +126,7 @@ public class ProductPredicate {
 
         builder.or(qProduct.brand.contains(keyword));
         builder.or(qProduct.name.contains(keyword));
+        builder.or(qProduct.brand.concat(" ").concat(qProduct.name).contains(keyword));
 
         return builder;
     }

--- a/src/main/java/com/pinkdumbell/cocobob/domain/product/ProductSearchQueryDslImpl.java
+++ b/src/main/java/com/pinkdumbell/cocobob/domain/product/ProductSearchQueryDslImpl.java
@@ -93,13 +93,13 @@ public class ProductSearchQueryDslImpl implements ProductSearchQueryDsl {
     public List<String> findProductNamesByKeyword(String keyword) {
         QProduct qProduct = QProduct.product;
 
-        List<Tuple> result = jpaQueryFactory.select(qProduct.brand, qProduct.name)
+        List<String> result = jpaQueryFactory
+            .select(qProduct.brand.concat(" ").concat(qProduct.name))
+            .distinct()
             .from(qProduct)
             .where(ProductPredicate.makeKeywordBooleanBuilder(keyword))
             .fetch();
 
-        return result.stream()
-            .map((tuple) -> tuple.get(qProduct.brand) + " " + tuple.get(qProduct.name))
-            .collect(Collectors.toList());
+        return result;
     }
 }

--- a/src/main/java/com/pinkdumbell/cocobob/exception/ErrorCode.java
+++ b/src/main/java/com/pinkdumbell/cocobob/exception/ErrorCode.java
@@ -13,7 +13,7 @@ public enum ErrorCode {
     INVALID_PASSWORD(HttpStatus.FORBIDDEN, "비밀번호가 일치하지 않습니다."),
     INVALID_REFRESH_TOKEN(HttpStatus.LOCKED, "유효하지 않은 Refresh 토큰입니다."),
     EXPIRED_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "기한이 만료된 Refresh 토큰입니다."),
-    BAD_REQUEST(HttpStatus.BAD_REQUEST, "BAD REQUEST"),
+    BAD_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
     NOT_IMAGE(HttpStatus.BAD_REQUEST, "올바른 이미지 파일이 아닙니다."),
     DUPLICATED_EMAIL(HttpStatus.CONFLICT, "해당 이메일을 가진 사용자가 존재합니다."),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "INTERNAL SERVER ERROR"),


### PR DESCRIPTION
[CB-370]

🔨 Jira 태스크
상품 키워드 제공 API가 없음

📐 구현한 내용
- 브랜드명, 상품명, f"{브랜드명} {상품명}"으로도 상품을 조회 가능하도록 booleanbuilder 값 변경
- sql 쿼리에서 concat을 사용하여 다른 두 열의 값을 하나로 만들어 조회 및 검색 조건으로 활용
- 따라서, 보다 유연성 있는 검색과 브랜드명과 상품명을 합쳐서도 검색이 가능


🚧 논의 사항
- 20개 이상 넘어가는 경우는 드물어 별도로 페이지 처리는 하지 않음
- 한글 특성상 초성 중성 종성으로 키워드 검색 고려 -> 유니코드 기반으로 검색이 이루어질 수 있도록 해야함
- 현재는 단순 문자열 포함 유무만을 확인
