### PR TITLE
Cb 370 상품 키워드 제공 api가 없음

### DIFF
--- a/src/main/java/com/pinkdumbell/cocobob/domain/product/ProductController.java
+++ b/src/main/java/com/pinkdumbell/cocobob/domain/product/ProductController.java
@@ -19,6 +19,7 @@ import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.data.domain.Pageable;
@@ -26,7 +27,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @ApiOperation("Product API")
@@ -56,10 +56,10 @@ public class ProductController {
     }
 
     private static class ProductKeywordResponseClass extends
-        CommonResponseDto<ProductKeywordDto> {
+        CommonResponseDto<List<ProductKeywordDto>> {
 
         public ProductKeywordResponseClass(int status, String code, String message,
-            ProductKeywordDto data) {
+            List<ProductKeywordDto> data) {
             super(status, code, message, data);
         }
     }

--- a/src/main/java/com/pinkdumbell/cocobob/domain/product/ProductSearchQueryDsl.java
+++ b/src/main/java/com/pinkdumbell/cocobob/domain/product/ProductSearchQueryDsl.java
@@ -1,5 +1,6 @@
 package com.pinkdumbell.cocobob.domain.product;
 
+import com.pinkdumbell.cocobob.domain.product.dto.ProductKeywordDto;
 import com.pinkdumbell.cocobob.domain.product.dto.ProductSimpleResponseDto;
 import com.pinkdumbell.cocobob.domain.product.dto.ProductSpecificSearchDto;
 import com.pinkdumbell.cocobob.domain.product.dto.ProductSpecificSearchWithLikeDto;
@@ -13,5 +14,5 @@ public interface ProductSearchQueryDsl {
     PageImpl<ProductSimpleResponseDto> findAllWithLikes(
         ProductSpecificSearchWithLikeDto productSpecificSearchDto, Long userId);
 
-    List<String> findProductNamesByKeyword(String keyword);
+    List<ProductKeywordDto> findProductNamesByKeyword(String keyword);
 }

--- a/src/main/java/com/pinkdumbell/cocobob/domain/product/ProductSearchQueryDslImpl.java
+++ b/src/main/java/com/pinkdumbell/cocobob/domain/product/ProductSearchQueryDslImpl.java
@@ -1,6 +1,7 @@
 package com.pinkdumbell.cocobob.domain.product;
 
 
+import com.pinkdumbell.cocobob.domain.product.dto.ProductKeywordDto;
 import com.pinkdumbell.cocobob.domain.product.dto.ProductSimpleResponseDto;
 import com.pinkdumbell.cocobob.domain.product.dto.ProductSpecificSearchWithLikeDto;
 import com.pinkdumbell.cocobob.domain.product.like.QLike;
@@ -56,7 +57,7 @@ public class ProductSearchQueryDslImpl implements ProductSearchQueryDsl {
             .where(
                 ProductBooleanBuilder.makeProductBooleanBuilder(productSpecificSearchWithLikeDto));
 
-        int totalElements = query.fetch().size();
+        long totalElements = query.fetch().size();
 
         if (productSpecificSearchWithLikeDto.getSort() != null) {
             String sortCriteria = productSpecificSearchWithLikeDto.getSort();
@@ -84,19 +85,22 @@ public class ProductSearchQueryDslImpl implements ProductSearchQueryDsl {
         Pageable pageable = PageRequest.of(productSpecificSearchWithLikeDto.getPage(),
             productSpecificSearchWithLikeDto.getSize());
 
-        return new PageImpl<>(result, pageable, (long) totalElements);
+        return new PageImpl<>(result, pageable, totalElements);
     }
 
-    public List<String> findProductNamesByKeyword(String keyword) {
+    public List<ProductKeywordDto> findProductNamesByKeyword(String keyword) {
         QProduct qProduct = QProduct.product;
 
-        List<String> result = jpaQueryFactory
-            .select(qProduct.brand.concat(" ").concat(qProduct.name))
+        return jpaQueryFactory
+            .select(Projections.constructor(
+                ProductKeywordDto.class,
+                qProduct.brand.as("brand"),
+                qProduct.name.as("name"),
+                qProduct.id.as("productId")
+            ))
             .distinct()
             .from(qProduct)
             .where(ProductBooleanBuilder.makeKeywordBooleanBuilder(keyword))
             .fetch();
-
-        return result;
     }
 }

--- a/src/main/java/com/pinkdumbell/cocobob/domain/product/ProductService.java
+++ b/src/main/java/com/pinkdumbell/cocobob/domain/product/ProductService.java
@@ -11,6 +11,7 @@ import com.pinkdumbell.cocobob.domain.user.User;
 import com.pinkdumbell.cocobob.domain.user.UserRepository;
 import com.pinkdumbell.cocobob.exception.CustomException;
 import com.pinkdumbell.cocobob.exception.ErrorCode;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.data.domain.Pageable;
@@ -72,7 +73,7 @@ public class ProductService {
         return new FindAllResponseDto(likeRepository.findAllByUserLike(user, pageable));
     }
 
-    public ProductKeywordDto getKeyword(String keyword) {
-        return new ProductKeywordDto(productRepository.findProductNamesByKeyword(keyword));
+    public List<ProductKeywordDto> getKeyword(String keyword) {
+        return productRepository.findProductNamesByKeyword(keyword);
     }
 }

--- a/src/main/java/com/pinkdumbell/cocobob/domain/product/dto/ProductKeywordDto.java
+++ b/src/main/java/com/pinkdumbell/cocobob/domain/product/dto/ProductKeywordDto.java
@@ -1,7 +1,6 @@
 package com.pinkdumbell.cocobob.domain.product.dto;
 
 import io.swagger.annotations.ApiModelProperty;
-import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -15,7 +14,11 @@ import lombok.Setter;
 @Setter
 public class ProductKeywordDto {
 
-    @ApiModelProperty(notes = "상품 리스트", example = "[펫 더 리얼, 리얼, ...]")
-    private List<String> names;
+    @ApiModelProperty(notes = "상품 브랜드", example = "로얄 캐닌")
+    private String brand;
+    @ApiModelProperty(notes = "상품명", example = "더 리얼..")
+    private String name;
+    @ApiModelProperty(notes = "상품 Id", example = "12")
+    private Long productId;
 
 }


### PR DESCRIPTION
[CB-370]

🔨 Jira 태스크
상품 키워드 제공 API가 없음


📐 구현한 내용
- 기존 keyword 검색시 제공한 '브랜드명 + 상품명'으로 제공한 것을 변경하였습니다.
- 이를 브랜드 명, 상품 명, 상품 Id로 나눈 객체에 담아 리스트로 전달

🚧 논의 사항
- 하나의 상품명으로 값을 전달하는 것이 아니라 추후 활용도를 높이기 위해 브랜드명, 상품명, 상품 ID를 제공



[CB-370]: https://cocobob.atlassian.net/browse/CB-370?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ