### PR TITLE
CB-423 [refactor]: remove redundant join table

### DIFF
--- a/src/main/java/com/pinkdumbell/cocobob/domain/product/ProductSearchQueryDslImpl.java
+++ b/src/main/java/com/pinkdumbell/cocobob/domain/product/ProductSearchQueryDslImpl.java
@@ -53,8 +53,6 @@ public class ProductSearchQueryDslImpl implements ProductSearchQueryDsl {
                             .where(qLike.user.id.eq(userId), qLike.product.id.eq(qProduct.id)),
                         "isLiked")))
             .from(qProduct)
-            .distinct()
-            .leftJoin(qLike).on(qProduct.id.eq(qLike.product.id))
             .where(
                 ProductBooleanBuilder.makeProductBooleanBuilder(productSpecificSearchWithLikeDto));
 
@@ -130,7 +128,6 @@ public class ProductSearchQueryDslImpl implements ProductSearchQueryDsl {
                             .where(qLike.user.id.eq(userId), qLike.product.id.eq(qProduct.id)),
                         "isLiked")))
             .from(qProduct)
-            .leftJoin(qLike).on(qProduct.id.eq(qLike.product.id))
             .where(qProduct.id.in(ids));
 
         long totalElements = query.fetch().size();


### PR DESCRIPTION

[CB-418]
[CB-423]

🔨 Jira 태스크
[BE] 상품 조회 데이터 뻥튀기 발생함


📐 구현한 내용
기존에는 좋아요 데이터와 상품을 조인할 필요성이 있었다. 그러나 쿼리의 서브 쿼리가 2개가 들어가게 되면서 join 할 필요가 없어졌다. 또한, 임시 방편으로 distinct를 하였지만, 한 상품의 좋아요 수에 따라서, row수가 엄청 많아지고 중복 처리를 DB가 모두 부담해야하는 문제가 있다. 그렇기에 여러 문제를 유발하는 LEFT JOIN을 제거하여 문제를 해결하였다.



🚧 논의 사항




[CB-418]: https://cocobob.atlassian.net/browse/CB-418?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CB-423]: https://cocobob.atlassian.net/browse/CB-423?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ