### PR TITLE
[CB-429] [BE] Daily Note 생성 API 리스폰스에 ID가 필요함

### DIFF
--- a/src/main/java/com/pinkdumbell/cocobob/domain/record/daily/DailyController.java
+++ b/src/main/java/com/pinkdumbell/cocobob/domain/record/daily/DailyController.java
@@ -30,18 +30,17 @@ public class DailyController {
             @ApiResponse(code = 400, message = "NOT_IMAGE", response = ErrorResponse.class)
     })
     @PostMapping("/pets/{petId}")
-    public ResponseEntity<CommonResponseDto> createDaily(
+    public ResponseEntity<DailyResponseClass.DailyCreateResponseClass> createDaily(
             @ModelAttribute @Valid DailyCreateRequestDto requestDto,
             @LoginUser LoginUserInfo loginUserInfo,
             @PathVariable Long petId
     ) {
-        dailyService.createDaily(requestDto, loginUserInfo, petId);
-        return ResponseEntity.ok(CommonResponseDto.builder()
-                        .status(HttpStatus.OK.value())
-                        .code("SUCCESS_CREATE_DAILY")
-                        .message("데일리 기록 생성을 성공하였습니다.")
-                        .data(null)
-                .build());
+        return ResponseEntity.ok(new DailyResponseClass.DailyCreateResponseClass(
+                HttpStatus.OK.value(),
+                "SUCCESS_CREATE_DAILY",
+                "데일리 기록 생성을 성공하였습니다.",
+                dailyService.createDaily(requestDto, loginUserInfo, petId)
+        ));
     }
 
     @ApiOperation(value = "데일리 아이디로 데일리 기록 단건 조회")

--- a/src/main/java/com/pinkdumbell/cocobob/domain/record/daily/DailyResponseClass.java
+++ b/src/main/java/com/pinkdumbell/cocobob/domain/record/daily/DailyResponseClass.java
@@ -1,6 +1,7 @@
 package com.pinkdumbell.cocobob.domain.record.daily;
 
 import com.pinkdumbell.cocobob.common.dto.CommonResponseDto;
+import com.pinkdumbell.cocobob.domain.record.daily.dto.DailyCreateResponseDto;
 import com.pinkdumbell.cocobob.domain.record.daily.dto.DailyDetailResponseDto;
 
 public class DailyResponseClass {
@@ -9,6 +10,13 @@ public class DailyResponseClass {
             CommonResponseDto<DailyDetailResponseDto> {
 
         public DailyDetailResponseClass(int status, String code, String message, DailyDetailResponseDto data) {
+            super(status, code, message, data);
+        }
+    }
+
+    public static class DailyCreateResponseClass extends
+            CommonResponseDto<DailyCreateResponseDto> {
+        public DailyCreateResponseClass(int status, String code, String message, DailyCreateResponseDto data) {
             super(status, code, message, data);
         }
     }

--- a/src/main/java/com/pinkdumbell/cocobob/domain/record/daily/DailyService.java
+++ b/src/main/java/com/pinkdumbell/cocobob/domain/record/daily/DailyService.java
@@ -2,6 +2,7 @@ package com.pinkdumbell.cocobob.domain.record.daily;
 
 import com.pinkdumbell.cocobob.common.ImageService;
 import com.pinkdumbell.cocobob.domain.record.daily.dto.DailyCreateRequestDto;
+import com.pinkdumbell.cocobob.domain.record.daily.dto.DailyCreateResponseDto;
 import com.pinkdumbell.cocobob.domain.record.daily.image.DailyImage;
 import com.pinkdumbell.cocobob.domain.record.daily.image.DailyImageRepository;
 import com.pinkdumbell.cocobob.domain.pet.PetRepository;
@@ -30,7 +31,7 @@ public class DailyService {
     private static final String DAILY_IMAGE_PREFIX = "daily/";
 
     @Transactional
-    public void createDaily(DailyCreateRequestDto requestDto, LoginUserInfo loginUserInfo, Long petId) {
+    public DailyCreateResponseDto createDaily(DailyCreateRequestDto requestDto, LoginUserInfo loginUserInfo, Long petId) {
         Daily daily = dailyRepository.save(Daily.builder()
                         .title(requestDto.getTitle())
                         .date(requestDto.getDate())
@@ -40,6 +41,7 @@ public class DailyService {
                         )
                 .build());
         saveImages(daily, requestDto.getImages());
+        return new DailyCreateResponseDto(daily);
     }
 
     @Transactional

--- a/src/main/java/com/pinkdumbell/cocobob/domain/record/daily/dto/DailyCreateResponseDto.java
+++ b/src/main/java/com/pinkdumbell/cocobob/domain/record/daily/dto/DailyCreateResponseDto.java
@@ -1,0 +1,13 @@
+package com.pinkdumbell.cocobob.domain.record.daily.dto;
+
+import com.pinkdumbell.cocobob.domain.record.daily.Daily;
+import lombok.Getter;
+
+@Getter
+public class DailyCreateResponseDto {
+    private final Long dailyId;
+
+    public DailyCreateResponseDto(Daily entity) {
+        dailyId = entity.getId();
+    }
+}


### PR DESCRIPTION
[CB-429]

🔨 Jira 태스크
- [CB-429] [BE] Daily Note 생성 API 리스폰스에 ID가 필요함


📐 구현한 내용
- 기존 daily 생성 시 null을 반환했는데, 클라이언트 요구에 따라 dailyId 반환


🚧 논의 사항




[CB-429]: https://cocobob.atlassian.net/browse/CB-429?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CB-429]: https://cocobob.atlassian.net/browse/CB-429?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ