### PR TITLE
[CB-127] [BE] 데이터 히스토리 테이블이 없음

### DIFF
--- a/src/main/java/com/pinkdumbell/cocobob/common/apilog/ApiLog.java
+++ b/src/main/java/com/pinkdumbell/cocobob/common/apilog/ApiLog.java
@@ -1,0 +1,28 @@
+package com.pinkdumbell.cocobob.common.apilog;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Entity
+@Table(name = "apilog")
+public class ApiLog {
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "log_id")
+    private Long id;
+    private String userEmail;
+    private String method;
+    private LocalDateTime time;
+    private String requestUrl;
+    private String handlerName;
+    private String queryString;
+    private String userAgent;
+}

--- a/src/main/java/com/pinkdumbell/cocobob/common/apilog/ApiLogInterceptor.java
+++ b/src/main/java/com/pinkdumbell/cocobob/common/apilog/ApiLogInterceptor.java
@@ -1,0 +1,43 @@
+package com.pinkdumbell.cocobob.common.apilog;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.time.LocalDateTime;
+
+@Component
+@RequiredArgsConstructor
+public class ApiLogInterceptor implements HandlerInterceptor {
+
+    private final ApiLogRepository apiLogRepository;
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
+        String userEmail = null;
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication != null) {
+            try {
+                userEmail = ((UserDetails) authentication.getPrincipal()).getUsername();
+            } catch (Exception e) {
+                userEmail = null;
+            }
+        }
+        apiLogRepository.save(ApiLog.builder()
+                        .userEmail(userEmail)
+                        .method(request.getMethod())
+                        .handlerName(handler.toString())
+                        .requestUrl(String.valueOf(request.getRequestURL()))
+                        .time(LocalDateTime.now())
+                        .queryString(request.getQueryString())
+                        .userAgent(request.getHeader("user-agent"))
+                .build());
+        return true;
+    }
+
+}

--- a/src/main/java/com/pinkdumbell/cocobob/common/apilog/ApiLogRepository.java
+++ b/src/main/java/com/pinkdumbell/cocobob/common/apilog/ApiLogRepository.java
@@ -1,0 +1,6 @@
+package com.pinkdumbell.cocobob.common.apilog;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ApiLogRepository extends JpaRepository<ApiLog, Long> {
+}

--- a/src/main/java/com/pinkdumbell/cocobob/config/WebConfig.java
+++ b/src/main/java/com/pinkdumbell/cocobob/config/WebConfig.java
@@ -1,11 +1,13 @@
 package com.pinkdumbell.cocobob.config;
 
+import com.pinkdumbell.cocobob.common.apilog.ApiLogInterceptor;
 import com.pinkdumbell.cocobob.config.annotation.loginuser.LoginUserArgumentResolver;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 import java.util.List;
@@ -15,6 +17,7 @@ import java.util.List;
 public class WebConfig implements WebMvcConfigurer {
 
     private final LoginUserArgumentResolver loginUserArgumentResolver;
+    private final ApiLogInterceptor apiLogInterceptor;
 
     @Override
     public void addCorsMappings(CorsRegistry registry) {
@@ -34,6 +37,15 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> argumentResolvers) {
         argumentResolvers.add(loginUserArgumentResolver);
+    }
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(apiLogInterceptor)
+                .addPathPatterns("/**")
+                .excludePathPatterns("/swagger-resources/**")
+                .excludePathPatterns("/v3/api-docs/**")
+                .excludePathPatterns("/swagger-ui/**");
     }
 
 }

--- a/src/main/resources/db/migration/V15__create_api_log.sql
+++ b/src/main/resources/db/migration/V15__create_api_log.sql
@@ -1,0 +1,13 @@
+
+create table apilog
+(
+    log_id      bigint auto_increment
+        primary key,
+    user_email  varchar(255) null,
+    method  varchar(10) null,
+    time    TIMESTAMP null,
+    request_url varchar(1000) null,
+    handler_name    varchar(1000) null,
+    query_string    varchar(1000) null,
+    user_agent      varchar(1000) null
+)


### PR DESCRIPTION
[CB-127]

🔨 Jira 태스크
[CB-127] [BE] 데이터 히스토리 테이블이 없음


📐 구현한 내용
- 인터셉트를 활용하여 API 로그 데이터를 축적할 수 있도록 구현.
  - 로그 데이터 테이블 생성
  - 인터셉트를 활용해서 API가 호출되면 핸들러에서 처리되기 이전에 로그가 쌓이도록 구현


🚧 논의 사항




[CB-127]: https://cocobob.atlassian.net/browse/CB-127?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CB-127]: https://cocobob.atlassian.net/browse/CB-127?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ