### PR TITLE
[CB-530] [BE] 식사 기록을 생성할 때 건강 기록이 생성되어 있지 않으면 생성할 수 없음

### DIFF
--- a/src/main/java/com/pinkdumbell/cocobob/domain/record/healthrecord/HealthRecordController.java
+++ b/src/main/java/com/pinkdumbell/cocobob/domain/record/healthrecord/HealthRecordController.java
@@ -7,9 +7,12 @@ import com.pinkdumbell.cocobob.domain.record.healthrecord.meal.dto.MealCreateReq
 import com.pinkdumbell.cocobob.domain.record.healthrecord.meal.dto.MealUpdateRequestDto;
 import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
 
 @ApiOperation("HealthRecord API")
 @RequiredArgsConstructor
@@ -19,31 +22,31 @@ public class HealthRecordController {
 
     private final HealthRecordService healthRecordService;
     @PostMapping("/pets/{petId}")
-    public ResponseEntity<CommonResponseDto> createHealthRecord(
+    public ResponseEntity<HealthRecordResponseClass.HealthRecordCreateResponseClass> createHealthRecord(
             @PathVariable Long petId,
             @ModelAttribute HealthRecordCreateRequestDto requestDto
     ) {
-        healthRecordService.createHealthRecord(petId, requestDto);
-        return ResponseEntity.ok(CommonResponseDto.builder()
-                .status(HttpStatus.OK.value())
-                .code("SUCCESS_TO_CREATE_HEALTH_RECORD")
-                .message("건강 기록 생성을 성공했습니다.")
-                .data(null)
-                .build());
+
+        return ResponseEntity.ok(new HealthRecordResponseClass.HealthRecordCreateResponseClass(
+                HttpStatus.OK.value(),
+                "SUCCESS_TO_CREATE_HEALTH_RECORD",
+                "건강 기록 생성을 성공했습니다.",
+                healthRecordService.createHealthRecord(petId, requestDto)
+        ));
     }
 
-    @PostMapping("/{healthRecordId}/meals")
-    public ResponseEntity<CommonResponseDto> createMeal(
-            @PathVariable Long healthRecordId,
+    @PostMapping("/pets/{petId}/dates/{date}/meal")
+    public ResponseEntity<HealthRecordResponseClass.HealthRecordCreateResponseClass> createMeal(
+            @PathVariable Long petId,
+            @PathVariable @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate date,
             @RequestBody MealCreateRequestDto requestDto
     ) {
-        healthRecordService.createMeal(healthRecordId, requestDto);
-        return ResponseEntity.ok(CommonResponseDto.builder()
-                        .status(HttpStatus.OK.value())
-                        .code("SUCCESS_TO_CREATE_MEAL")
-                        .message("식사 기록 생성을 성공했습니다.")
-                        .data(null)
-                .build());
+        return ResponseEntity.ok(new HealthRecordResponseClass.HealthRecordCreateResponseClass(
+                HttpStatus.OK.value(),
+                "SUCCESS_TO_CREATE_MEAL",
+                "식사 기록 생성을 성공했습니다.",
+                healthRecordService.createMeal(petId, date, requestDto)
+        ));
     }
 
     @GetMapping("/{healthRecordId}")

--- a/src/main/java/com/pinkdumbell/cocobob/domain/record/healthrecord/HealthRecordResponseClass.java
+++ b/src/main/java/com/pinkdumbell/cocobob/domain/record/healthrecord/HealthRecordResponseClass.java
@@ -1,6 +1,7 @@
 package com.pinkdumbell.cocobob.domain.record.healthrecord;
 
 import com.pinkdumbell.cocobob.common.dto.CommonResponseDto;
+import com.pinkdumbell.cocobob.domain.record.healthrecord.dto.HealthRecordCreateResponseDto;
 import com.pinkdumbell.cocobob.domain.record.healthrecord.dto.HealthRecordDetailResponseDto;
 import com.pinkdumbell.cocobob.domain.record.healthrecord.dto.RecentWeightsResponseDto;
 
@@ -18,6 +19,14 @@ public class HealthRecordResponseClass {
             CommonResponseDto<RecentWeightsResponseDto> {
 
         public RecentWeightsResponseClass(int status, String code, String message, RecentWeightsResponseDto data) {
+            super(status, code, message, data);
+        }
+    }
+
+    public static class HealthRecordCreateResponseClass extends
+            CommonResponseDto<HealthRecordCreateResponseDto> {
+
+        public HealthRecordCreateResponseClass(int status, String code, String message, HealthRecordCreateResponseDto data) {
             super(status, code, message, data);
         }
     }

--- a/src/main/java/com/pinkdumbell/cocobob/domain/record/healthrecord/dto/HealthRecordCreateResponseDto.java
+++ b/src/main/java/com/pinkdumbell/cocobob/domain/record/healthrecord/dto/HealthRecordCreateResponseDto.java
@@ -1,0 +1,13 @@
+package com.pinkdumbell.cocobob.domain.record.healthrecord.dto;
+
+import com.pinkdumbell.cocobob.domain.record.healthrecord.HealthRecord;
+import lombok.Getter;
+
+@Getter
+public class HealthRecordCreateResponseDto {
+    private final Long healthRecordId;
+
+    public HealthRecordCreateResponseDto(HealthRecord entity) {
+        this.healthRecordId = entity.getId();
+    }
+}


### PR DESCRIPTION
[CB-530]

🔨 Jira 태스크
[CB-530] [BE] 식사 기록을 생성할 때 건강 기록이 생성되어 있지 않으면 생성할 수 없음

📐 구현한 내용
- 건강 기록, 식사 기록 생성 시 건강 기록 아이디를 반환할 수 있도록 수정
- 식사 기록 생성 시, 건강 기록 아이디를 받는 것이 아닌, 날짜를 받아서 건강 기록 존재를 확인한 후 findOrCreate 방식으로 건강기록을 생성하고 식사기록 데이터를 추가.

🚧 논의 사항




[CB-530]: https://cocobob.atlassian.net/browse/CB-530?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CB-530]: https://cocobob.atlassian.net/browse/CB-530?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ