### PR TITLE
[CB-539] [BE] 건강 기록 급여기록 리스폰스에서 급여 사료의 정보가 부족함

### DIFF
--- a/src/main/java/com/pinkdumbell/cocobob/domain/product/ProductRepository.java
+++ b/src/main/java/com/pinkdumbell/cocobob/domain/product/ProductRepository.java
@@ -8,7 +8,7 @@ import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 public interface ProductRepository extends JpaRepository<Product, Long>,
     JpaSpecificationExecutor<Product>,ProductSearchQueryDsl {
 
-    @Cacheable(cacheNames = "productDetails", key = "#productId")
+    @Cacheable(cacheNames = "productDetails")
     @Override
     Optional<Product> findById(Long productId);
 

--- a/src/main/java/com/pinkdumbell/cocobob/domain/record/healthrecord/dto/HealthRecordDetailResponseDto.java
+++ b/src/main/java/com/pinkdumbell/cocobob/domain/record/healthrecord/dto/HealthRecordDetailResponseDto.java
@@ -28,8 +28,8 @@ public class HealthRecordDetailResponseDto {
     @Getter
     public static class RecentBodyWeightResponseDto {
         @JsonFormat(pattern = "yyyy-MM-dd")
-        private LocalDate date;
-        private Double bodyWeight;
+        private final LocalDate date;
+        private final Double bodyWeight;
 
         public RecentBodyWeightResponseDto(HealthRecord entity) {
             this.date = entity.getDate();
@@ -69,10 +69,14 @@ public class HealthRecordDetailResponseDto {
         public static class ProductSimpleInfoDto {
             private final Long productId;
             private final String productName;
+            private final String brand;
+            private final String thumbnail;
 
-            public ProductSimpleInfoDto(Long productId, String productName) {
+            public ProductSimpleInfoDto(Long productId, String productName, String brand, String thumbnail) {
                 this.productId = productId;
                 this.productName = productName;
+                this.brand = brand;
+                this.thumbnail = thumbnail;
             }
         }
 
@@ -82,9 +86,9 @@ public class HealthRecordDetailResponseDto {
             this.amount = entity.getAmount();
             Product product = entity.getProduct();
             if (product != null) {
-                this.productInfo = new ProductSimpleInfoDto(product.getId(), product.getName());
+                this.productInfo = new ProductSimpleInfoDto(product.getId(), product.getName(), product.getBrand(), product.getThumbnail());
             } else {
-                this.productInfo = new ProductSimpleInfoDto(null, entity.getProductName());
+                this.productInfo = new ProductSimpleInfoDto(null, entity.getProductName(), null, null);
             }
         }
     }


### PR DESCRIPTION

[CB-539]

🔨 Jira 태스크
- [CB-539] [BE] 건강 기록 급여기록 리스폰스에서 급여 사료의 정보가 부족함


📐 구현한 내용
- 건강 기록 조회 시 식사 기록 내에 등록된 상품이 포함된다 상품 브랜드 상품 사진을 보내주도록 변경
- 캐싱 null key 이슈로 key 값 지정 삭제


🚧 논의 사항




[CB-539]: https://cocobob.atlassian.net/browse/CB-539?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CB-539]: https://cocobob.atlassian.net/browse/CB-539?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ